### PR TITLE
Replace disconnected users with bots:

### DIFF
--- a/public/js/draft.js
+++ b/public/js/draft.js
@@ -419,11 +419,10 @@ var app = new Vue({
 					position: 'center',
 					customClass: { popup: 'custom-swal-popup', title: 'custom-swal-title', content: 'custom-swal-content' },
 					type: 'error',
-					title: 'A user disconnected, canceling draft...',
+					title: 'A user disconnected, replacing with a bot...',
 					showConfirmButton: false,
 					timer: 1500
 				});
-				app.drafting = false;
 			}
 			
 			app.sessionUsers = users;

--- a/server.js
+++ b/server.js
@@ -670,10 +670,15 @@ function getUserID(req, res) {
 function removeUserFromSession(userID, sessionID) {
 	if(sessionID in Sessions) {
 		if(Sessions[sessionID].drafting) {
-			// Clients should stop drafting automatically
-			Sessions[sessionID].drafting = false;
+			Sessions[sessionID].bots += 1;
+			if (!Sessions[sessionID].botsInstances) {
+				Sessions[sessionID].botsInstances = [];
+				Sessions[sessionID].botsInstances.push(new Bot());
+			} else {
+				Sessions[sessionID].botsInstances.push(new Bot());
+			}
 		}
-
+		
 		Sessions[sessionID].users.delete(userID);
 		Connections[userID].sessionID = undefined;
 		if(Sessions[sessionID].users.size == 0) {


### PR DESCRIPTION
- Updated front end and back end to no longer set drafting to false when a user disconnects
- Update `removeUserFromSession` method to increment bots by one and add a new Bot object to the botsInstances array
- when a user disconnects, front end now shows message of `A user disconnected, replacing with a bot…`