### PR TITLE
Custom Colors

### DIFF
--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -1,24 +1,8 @@
 import type { ClientToServerEvents, LoaderOptions, ServerToClientEvents } from "@/SocketType";
 import type { UserID } from "@/IDTypes";
 import type { SetCode, IIndexable, Language } from "@/Types";
-import {
-	DisconnectedUser,
-	DistributionMode,
-	DraftLogRecipients,
-	ReadyState,
-	UserData,
-	UsersData,
-} from "../../src/Session/SessionTypes";
-import {
-	ArenaID,
-	Card,
-	CardID,
-	DeckList,
-	OnPickDraftEffect,
-	PlainCollection,
-	UniqueCard,
-	UniqueCardID,
-} from "@/CardTypes";
+import { DistributionMode, DraftLogRecipients, ReadyState, UserData, UsersData } from "../../src/Session/SessionTypes";
+import { ArenaID, Card, CardID, DeckList, PlainCollection, UniqueCard, UniqueCardID } from "@/CardTypes";
 import type { DraftLog } from "@/DraftLog";
 import type { BotScores } from "@/Bot";
 import type { WinstonDraftSyncData } from "@/WinstonDraft";
@@ -40,7 +24,7 @@ import Constants, { CubeDescription, EnglishBasicLandNames } from "../../src/Con
 import { CardColor, OptionalOnPickDraftEffect, UsableDraftEffect } from "../../src/CardTypes";
 
 import io, { Socket } from "socket.io-client";
-import { toRaw, defineComponent, defineAsyncComponent } from "vue";
+import { toRaw, defineComponent, defineAsyncComponent, computed } from "vue";
 import { Sortable } from "sortablejs-vue3";
 import Swal, { SweetAlertIcon, SweetAlertOptions, SweetAlertResult } from "sweetalert2";
 import { SortableEvent } from "sortablejs";
@@ -414,6 +398,22 @@ export default defineComponent({
 				text: string;
 				timestamp: number;
 			}[],
+		};
+	},
+	provide() {
+		return {
+			cardColors: computed(() => {
+				const CardColors = {
+					W: { id: "W", icon: "img/mana/W.svg" },
+					U: { id: "U", icon: "img/mana/U.svg" },
+					B: { id: "B", icon: "img/mana/B.svg" },
+					R: { id: "R", icon: "img/mana/R.svg" },
+					G: { id: "G", icon: "img/mana/G.svg" },
+				};
+				if (this.customCardList?.settings?.colors)
+					return { ...CardColors, ...this.customCardList.settings.colors };
+				return CardColors;
+			}),
 		};
 	},
 	methods: {

--- a/src/CustomCardList.ts
+++ b/src/CustomCardList.ts
@@ -17,6 +17,8 @@ export type CCLSettings = {
 	withReplacement?: boolean;
 	predeterminedLayouts?: { name: LayoutName; weight: number }[][];
 	layoutWithReplacement?: boolean;
+	colors?: Record<string, { id: string; symbol: string; name: string }>;
+	symbols?: Record<string, { symbol: string; icon: string; cmc: number; colors: string[] }>;
 };
 
 export type CustomCardList = {

--- a/src/CustomCards.ts
+++ b/src/CustomCards.ts
@@ -4,6 +4,7 @@ import { Card, CardColor, CardFace } from "./CardTypes.js";
 import { ackError, isMessageError, isSocketError, SocketAck, SocketError } from "./Message.js";
 import { isCard, isDraftEffect } from "./CardTypeCheck.js";
 import { hasProperty, isArrayOf, isObject, isRecord, isString } from "./TypeChecks.js";
+import { CCLSettings } from "./CustomCardList";
 
 function errorWithJSON(title: string, msg: string, json: unknown) {
 	return ackError({
@@ -58,7 +59,7 @@ export function validateCustomCardFace(face: unknown): SocketError | CardFace {
 	};
 }
 
-export function validateCustomCard(inputCard: any): SocketError | Card {
+export function validateCustomCard(inputCard: any, settings?: CCLSettings): SocketError | Card {
 	// Check mandatory fields
 	const missing =
 		checkProperty(inputCard, "name") ??
@@ -128,7 +129,7 @@ export function validateCustomCard(inputCard: any): SocketError | Card {
 	const card = new Card();
 	card.is_custom = true;
 	card.name = card.id = card.oracle_id = inputCard.name;
-	const ret = parseCost(inputCard.mana_cost);
+	const ret = parseCost(inputCard.mana_cost, settings);
 	if (isMessageError(ret)) return new SocketAck(ret);
 	const { cmc, colors, normalizedCost } = ret;
 	card.mana_cost = normalizedCost;

--- a/src/parseCost.ts
+++ b/src/parseCost.ts
@@ -1,4 +1,5 @@
 import { CardColor } from "./CardTypes";
+import { CCLSettings } from "./CustomCardList";
 import ManaSymbolsJSON from "./data/mana_symbols.json" assert { type: "json" };
 import { MessageError } from "./Message.js";
 
@@ -7,13 +8,17 @@ const ManaSymbols: { [key: string]: { cmc: number | null; colors: string[] } } =
 
 const ManaSymbolMaxLength = Object.keys(ManaSymbols).reduce((max, key) => Math.max(max, key.length), 0);
 
-export default function parseCost(cost: string): MessageError | parseCostReturnType {
+export default function parseCost(cost: string, settings?: CCLSettings): MessageError | parseCostReturnType {
 	const r: parseCostReturnType = {
 		cmc: 0,
 		colors: [],
 		normalizedCost: "",
 	};
 	if (!cost || cost === "") return r;
+
+	const customSymbolMaxLength = settings?.symbols
+		? Object.keys(settings?.symbols).reduce((max, key) => Math.max(max, key.length), 0)
+		: 0;
 
 	// Use only the first part of split cards
 	const frontCost = cost.includes("//") ? cost.split("//")[0].trim() : cost;
@@ -28,10 +33,10 @@ export default function parseCost(cost: string): MessageError | parseCostReturnT
 			index = endIdx + 1;
 		} else {
 			// Not using the scryfall syntax, try to match symbols using a greedy approach
-			let l = ManaSymbolMaxLength;
+			let l = Math.max(ManaSymbolMaxLength, customSymbolMaxLength);
 			while (l > 0) {
 				const s = `{${frontCost.slice(index, index + l)}}`;
-				if (s in ManaSymbols) {
+				if (s in ManaSymbols || (settings?.symbols && s in settings.symbols)) {
 					symbols.push(s);
 					index += l;
 					break;
@@ -47,13 +52,14 @@ export default function parseCost(cost: string): MessageError | parseCostReturnT
 	}
 
 	for (const s of symbols) {
-		if (!(s in ManaSymbols))
+		const symbol = settings?.symbols?.[s] ?? ManaSymbols[s];
+		if (!symbol)
 			return new MessageError(
 				"Invalid Mana Cost",
 				`Error parsing mana cost '${cost}': '${s}' is not a valid mana symbol. Refer to https://scryfall.com/docs/api/colors for a list of valid symbols.`
 			);
-		r.cmc += ManaSymbols[s].cmc ?? 0;
-		r.colors = r.colors.concat(ManaSymbols[s].colors as CardColor[]);
+		r.cmc += symbol.cmc ?? 0;
+		r.colors = r.colors.concat(symbol.colors as CardColor[]);
 	}
 
 	r.normalizedCost = symbols.join("");

--- a/test/data/CustomColors.txt
+++ b/test/data/CustomColors.txt
@@ -1,0 +1,40 @@
+[Settings]
+{
+	"withReplacement": true,
+	"colors": [{"id": "NewA", "symbol": "{NewA}", "name": "NewA", "basic": "NewA"}, {"id": "NewB", "symbol": "{NewB}", "name": "NewB", "basic": "NewB"}],
+	"symbols": [{"symbol": "{NewA}", "icon": "https://svgs.scryfall.io/card-symbols/T.svg", "cmc": 1, "colors": ["NewA"]}, {"symbol": "{NewB}", "icon": "https://svgs.scryfall.io/card-symbols/Q.svg", "cmc": 1, "colors": ["NewB"]}]
+}
+[CustomCards]
+[
+	{	
+		"name": "NewA",
+		"rarity": "mythic",
+		"mana_cost": "{1}{NewA}",
+		"type": "Creature",
+		"image_uris": {
+			"en": "https://cards.scryfall.io/border_crop/front/6/0/60e16d94-1166-4050-8554-686e153a7f80.jpg?1576381454"
+		}
+	},
+	{	
+		"name": "NewB",
+		"rarity": "mythic",
+		"mana_cost": "{1}{NewB}",
+		"type": "Creature",
+		"image_uris": {
+			"en": "https://cards.scryfall.io/border_crop/front/e/3/e384c20b-d0c1-4781-9d11-e89e5a6bf3fc.jpg?1686967821"
+		}
+	},
+	{	
+		"name": "NewAB",
+		"rarity": "mythic",
+		"mana_cost": "{NewA}{NewB}",
+		"type": "Creature",
+		"image_uris": {
+			"en": "https://cards.scryfall.io/border_crop/front/e/7/e724c648-0585-451f-afcd-7efff2521151.jpg?1599354187"
+		}
+	}
+]
+[Default]
+NewA
+NewB
+NewAB


### PR DESCRIPTION
Adds a settings in Custom Card Lists to specify custom colors and mana symbols.

```
[Settings]
{
	"withReplacement": true,
	"colors": [
		{"id": "NewA", "symbol": "{NewA}", "name": "NewA", "basic": "NewA"}, 
		{"id": "NewB", "symbol": "{NewB}", "name": "NewB", "basic": "NewB"}
	],
	"symbols": [
		{"symbol": "{NewA}", "icon": "https://svgs.scryfall.io/card-symbols/T.svg", "cmc": 1, "colors": ["NewA"]},
		{"symbol": "{NewB}", "icon": "https://svgs.scryfall.io/card-symbols/Q.svg", "cmc": 1, "colors": ["NewB"]}
	]
}
```

 - [x] Parsing
        Kinda, format will probably evolve quite a bit.
 - [ ] Color balancing support. 
 - [ ] UI Support
        That's the hard part.