### PR TITLE
Filter FINBoosterFactory.BorderlessCharacter to remove duplicate Kuja

### DIFF
--- a/src/BoosterFactory.ts
+++ b/src/BoosterFactory.ts
@@ -3318,7 +3318,7 @@ export class FINBoosterFactory extends BoosterFactory {
 	static readonly BorderlessAdventure = FINBoosterFactory.filter(310, 314);
 	static readonly BorderlessArtist = [...FINBoosterFactory.filter(315, 323), ...FINBoosterFactory.filter(577, 577)];
 	static readonly BorderlessWoodblock = FINBoosterFactory.filter(324, 373); // 50
-	static readonly BorderlessCharacter = FINBoosterFactory.filter(374, 405); // 32
+	static readonly BorderlessCharacter = FINBoosterFactory.filter(374, 405).filter((c) => getCard(c).collector_number.match(/^\d+$/)); // 32
 	static readonly CidVariants = [...FINBoosterFactory.filter(216, 216), ...FINBoosterFactory.filter(407, 420)];
 	static readonly Basics = FINBoosterFactory.filter(294, 309);
 	static readonly CommonDualLands = [


### PR DESCRIPTION
Kuja FIN 399 is duplicated in this data set as scryfall tracks a variant of this card.

I applied a similar fix as the one for FCA in this same booster factory.

Fixes #978 