### PR TITLE
Booster Contents

### DIFF
--- a/client/public/cubeformat.html
+++ b/client/public/cubeformat.html
@@ -698,6 +698,7 @@ CogworkGrinder             <comment># Will display the number of cards removed b
 
 <comment># The following effects are custom and do not match official Conspiracy effects.</comment>
 AddCards            <comment># Adds additional cards to your draft pool.</comment>
+BoosterContents     <comment># Seeds the packs of a LoreSeeker effect. </comment>
 
 <comment># Example value for AddCards</comment>
 "draft_effects": [
@@ -706,6 +707,25 @@ AddCards            <comment># Adds additional cards to your draft pool.</commen
 		"count": 1, <comment># Optional, if omitted, all cards from the following array will be added. Otherwise, 'count' random cards will be added to your pool.</comment>
 		"cards": ["Card Name 1", "Card Name 2"...],
 		"duplicateProtection": true, <comment># Optional, defaults to true. Duplicates of the same card can be used to increase its probability of being picked.</comment>
+	}
+]
+<comment># Example value for BoosterContents</comment>
+"draft_effects": [
+	"Reveal",
+	"LoreSeaker",
+	<comment>Pack style 1. Does nothing without LoreSeeker</comment>
+	{
+		"type": "BoosterContents",
+		"count": 1, <comment># Optional, if omitted, all cards from the following array will be in the pack. Otherwise, 'count' random cards will be in the pack.</comment>
+		"cards": ["Card Name 1", "Card Name 2"...],
+		"duplicateProtection": true, <comment># Optional, defaults to true. Duplicates of the same card can be used to increase its probability of being picked.</comment>
+	},
+	<comment>#Optional, Pack style 2. Can repeat as many times as you'd like.</comment>
+	{
+		"type": "BoosterContents",
+		"count": 1,
+		"cards": ["Card Name 1", "Card Name 2"...],
+		"duplicateProtection": true,
 	}
 ]
 </pre>

--- a/client/public/cubeformat.html
+++ b/client/public/cubeformat.html
@@ -713,14 +713,14 @@ BoosterContents     <comment># Seeds the packs of a LoreSeeker effect. </comment
 "draft_effects": [
 	"Reveal",
 	"LoreSeaker",
-	<comment>Pack style 1. Does nothing without LoreSeeker</comment>
+	<comment># Pack style 1. Does nothing without LoreSeeker</comment>
 	{
 		"type": "BoosterContents",
 		"count": 1, <comment># Optional, if omitted, all cards from the following array will be in the pack. Otherwise, 'count' random cards will be in the pack.</comment>
 		"cards": ["Card Name 1", "Card Name 2"...],
 		"duplicateProtection": true, <comment># Optional, defaults to true. Duplicates of the same card can be used to increase its probability of being picked.</comment>
 	},
-	<comment>#Optional, Pack style 2. Can repeat as many times as you'd like.</comment>
+	<comment># Optional, Pack style 2. Can repeat as many times as you'd like.</comment>
 	{
 		"type": "BoosterContents",
 		"count": 1,

--- a/src/CardTypeCheck.ts
+++ b/src/CardTypeCheck.ts
@@ -47,6 +47,8 @@ export function isDraftEffect(obj: unknown): obj is DraftEffect {
 	if (!hasProperty("type", isDraftEffectType)(obj)) return false;
 	if (obj.type === ParameterizedDraftEffectType.AddCards)
 		return hasProperty("count", isInteger)(obj) && hasProperty("cards", isArrayOf(isString))(obj);
+	if (obj.type === ParameterizedDraftEffectType.BoosterContents)
+		return hasProperty("count", isInteger)(obj) && hasProperty("cards", isArrayOf(isString))(obj);
 	return hasProperty("type", isSimpleDraftEffectType)(obj);
 }
 

--- a/src/CardTypes.ts
+++ b/src/CardTypes.ts
@@ -50,6 +50,7 @@ export type SimpleDraftEffectType =
 
 export enum ParameterizedDraftEffectType {
 	AddCards = "AddCards",
+	BoosterContents = "BoosterContents",
 }
 
 export type DraftEffectType = SimpleDraftEffectType | ParameterizedDraftEffectType;
@@ -58,7 +59,8 @@ export type DraftEffect =
 	| {
 			type: SimpleDraftEffectType;
 	  }
-	| { type: ParameterizedDraftEffectType.AddCards; count: number; cards: CardID[]; duplicateProtection: boolean };
+	| { type: ParameterizedDraftEffectType.AddCards; count: number; cards: CardID[]; duplicateProtection: boolean }
+	| { type: ParameterizedDraftEffectType.BoosterContents; count: number; cards: CardID[]; duplicateProtection: boolean };
 
 export type CardFace = {
 	name: string;

--- a/src/CustomCards.ts
+++ b/src/CustomCards.ts
@@ -280,6 +280,37 @@ export function validateCustomCard(inputCard: any): SocketError | Card {
 						cards: entry.cards,
 						duplicateProtection: entry.duplicateProtection ?? true,
 					});
+				} else if (entry.type === ParameterizedDraftEffectType.BoosterContents) {
+					if (!hasProperty("cards", isArrayOf(isString))(entry)) {
+						return valErr(
+							`Invalid Parameter`,
+							`Invalid 'AddCards' entry in 'draft_effects' of custom card. Missing or invalid 'cards' parameter.`
+						);
+					}
+					if (!hasOptionalProperty("count", isInteger)(entry)) {
+						return valErr(
+							`Invalid Parameter`,
+							`Invalid 'AddCards' entry in 'draft_effects' of custom card. Invalid 'count' parameter.`
+						);
+					}
+					if (!hasOptionalProperty("duplicateProtection", isBoolean)(entry)) {
+						return valErr(
+							`Invalid Parameter`,
+							`Invalid 'AddCards' entry in 'draft_effects' of custom card. Invalid 'duplicateProtection' parameter.`
+						);
+					}
+					if (entry.count && entry.count <= 0)
+						return valErr(
+							`Invalid Parameter`,
+							`Invalid 'AddCards' entry in 'draft_effects' of custom card. 'count' must be strictly positive.`
+						);
+						// NOTE: Full verification of the cards will be done later, once the rest of the file is parsed.
+						card.draft_effects.push({
+							type: entry.type,
+							count: entry.count ?? 0, // NOTE: If 0, will be filled after validation (we want to set it to all cards, but their count is unknown until parsed)
+							cards: entry.cards,
+							duplicateProtection: entry.duplicateProtection ?? true,
+						});
 				} else {
 					return valErr(
 						`Invalid Property`,

--- a/src/CustomCards.ts
+++ b/src/CustomCards.ts
@@ -284,25 +284,25 @@ export function validateCustomCard(inputCard: any): SocketError | Card {
 					if (!hasProperty("cards", isArrayOf(isString))(entry)) {
 						return valErr(
 							`Invalid Parameter`,
-							`Invalid 'AddCards' entry in 'draft_effects' of custom card. Missing or invalid 'cards' parameter.`
+							`Invalid 'BoosterContents' entry in 'draft_effects' of custom card. Missing or invalid 'cards' parameter.`
 						);
 					}
 					if (!hasOptionalProperty("count", isInteger)(entry)) {
 						return valErr(
 							`Invalid Parameter`,
-							`Invalid 'AddCards' entry in 'draft_effects' of custom card. Invalid 'count' parameter.`
+							`Invalid 'BoosterContents' entry in 'draft_effects' of custom card. Invalid 'count' parameter.`
 						);
 					}
 					if (!hasOptionalProperty("duplicateProtection", isBoolean)(entry)) {
 						return valErr(
 							`Invalid Parameter`,
-							`Invalid 'AddCards' entry in 'draft_effects' of custom card. Invalid 'duplicateProtection' parameter.`
+							`Invalid 'BoosterContents' entry in 'draft_effects' of custom card. Invalid 'duplicateProtection' parameter.`
 						);
 					}
 					if (entry.count && entry.count <= 0)
 						return valErr(
 							`Invalid Parameter`,
-							`Invalid 'AddCards' entry in 'draft_effects' of custom card. 'count' must be strictly positive.`
+							`Invalid 'BoosterContents' entry in 'draft_effects' of custom card. 'count' must be strictly positive.`
 						);
 						// NOTE: Full verification of the cards will be done later, once the rest of the file is parsed.
 						card.draft_effects.push({

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -2231,10 +2231,32 @@ export class Session implements IIndexable {
 						return reportError("Invalid draft effect card.");
 					if (!pickedCards.includes(index))
 						return reportError("You must pick Lore Seeker to use its effect.");
-					const additionalBooster = this.generateBoosters(1, {
-						useCustomBoosters: true,
-						removeFromCardPool: this.draftLog?.boosters.flat(),
-					});
+					//      if(hasEffect(booster[index], ParameterizedDraftEffectType.BoosterContents))
+
+					const effect =
+						random.shuffle(
+							booster[index].draft_effects?.filter(
+								(ef) => ef.type == ParameterizedDraftEffectType.BoosterContents
+							) ?? []
+						)[0] ?? null;
+					const shuffled = random.shuffle(effect?.cards ?? []);
+					const uniques = effect?.duplicateProtection
+						? shuffled.filter((name, index) => shuffled.indexOf(name) === index)
+						: shuffled;
+
+					const additionalBooster = effect
+						? effect.count == effect.cards.length
+							? [effect.cards.map((cid) => getUnique(cid, { getCard: this.getCustomGetCardFunction() }))]
+							: [
+									uniques
+										.splice(0, effect.count)
+										.map((cid) => getUnique(cid, { getCard: this.getCustomGetCardFunction() })),
+								]
+						: this.generateBoosters(1, {
+								useCustomBoosters: true,
+								removeFromCardPool: this.draftLog?.boosters.flat(),
+							});
+
 					if (isMessageError(additionalBooster))
 						Connections[userID].socket?.emit(
 							"message",

--- a/src/parseCardList.ts
+++ b/src/parseCardList.ts
@@ -616,11 +616,11 @@ function parseCustomCards(lines: string[], startIdx: number) {
 								title: `[CustomCards]`,
 								text: `'${cid}', referenced in '${card.name}' ${effect.type} draft effect, is not a valid card.`,
 							});
-							effect.cards[i] = result.cardID;
-							// Insert additional copies of the card if needed.
-							for (let count = 1; count < result.count; ++count) {
-								effect.cards.splice(++i, 0, result.cardID);
-							}
+						effect.cards[i] = result.cardID;
+						// Insert additional copies of the card if needed.
+						for (let count = 1; count < result.count; ++count) {
+							effect.cards.splice(++i, 0, result.cardID);
+						}
 					}
 					// Actual card count is now known, update the 'count' field if unspecified and validate it.
 					if (effect.count <= 0) effect.count = effect.cards.length;
@@ -631,6 +631,7 @@ function parseCustomCards(lines: string[], startIdx: number) {
 						});
 					}
 				}
+			}
 		}
 	}
 

--- a/src/parseCardList.ts
+++ b/src/parseCardList.ts
@@ -602,8 +602,35 @@ function parseCustomCards(lines: string[], startIdx: number) {
 							text: `Invalid 'AddCards' entry in 'draft_effects' of '${card.name}'. 'count' (${effect.count}) must be strictly positive and less than or equal to the number of cards in 'cards' (${effect.cards.length}).`,
 						});
 					}
+				} else if (effect.type === ParameterizedDraftEffectType.BoosterContents) {
+					for (let i = 0; i < effect.cards.length; ++i) {
+						const cid = effect.cards[i];
+						// This is a valid card ID, nothing more to do.
+						if (isValidCardID(cid)) continue;
+						// Otherwise, treat it as a card line and replace it with the corresponding Card ID.
+						const result = parseLine(cid, {
+							customCards: { cards: customCardsIDs, nameCache: customCardsNameCache },
+						});
+						if (isSocketError(result))
+							return ackError({
+								title: `[CustomCards]`,
+								text: `'${cid}', referenced in '${card.name}' ${effect.type} draft effect, is not a valid card.`,
+							});
+							effect.cards[i] = result.cardID;
+							// Insert additional copies of the card if needed.
+							for (let count = 1; count < result.count; ++count) {
+								effect.cards.splice(++i, 0, result.cardID);
+							}
+					}
+					// Actual card count is now known, update the 'count' field if unspecified and validate it.
+					if (effect.count <= 0) effect.count = effect.cards.length;
+					if (effect.count <= 0 || effect.count > effect.cards.length) {
+						return ackError({
+							title: `Invalid Parameter`,
+							text: `Invalid 'BoosterContents' entry in 'draft_effects' of '${card.name}'. 'count' (${effect.count}) must be strictly positive and less than or equal to the number of cards in 'cards' (${effect.cards.length}).`,
+						});
+					}
 				}
-			}
 		}
 	}
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -2109,7 +2109,7 @@ app.get("/getBracket/:sessionID", (req, res) => {
 	}
 });
 
-app.get(["/getDraftLog/:sessionID", "/api/getDraftLog/:sessionID"], (req, res) => {
+app.get<{ sessionID: string }>(["/getDraftLog/:sessionID", "/api/getDraftLog/:sessionID"], (req, res) => {
 	const sessionID = req.params.sessionID;
 	if (!sessionID) {
 		res.sendStatus(400);


### PR DESCRIPTION
• Added the BoosterContents draft effect to seed LoreSeeker packs
• Fixed a compile error in server.ts
• Added BoosterContents to cubeformat.html

BoosterContents uses the same signature as AddCards, meaning type and cards are required, count and duplicateProtection are optional. It selects random cards for the booster in the same way AddCards selects cards for your pool.

Multiple BoosterContents tags are meaningful: a random BoosterContents effect is chosen, so different counts, pools, and duplicate protections are provided. 2x Pack 1 and 1x Pack 2 makes Pack 1 twice as likely to appear, same as with cards in the effects.

However, I have no current plans to implement a limited pool of packs that deplete, nor duplicate protection for said pool.