### PR TITLE
Add spectator mode via owner-shared invite links

### DIFF
--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -3107,18 +3107,19 @@ export default defineComponent({
 		},
 		removePlayer(userID: UserID) {
 			if (this.userID !== this.sessionOwner) return;
-			const user =
-				this.sessionUsers.find((u) => u.userID === userID) ??
-				this.sessionSpectators.find((s) => s.userID === userID);
+			const player = this.sessionUsers.find((u) => u.userID === userID);
+			const spectator = this.sessionSpectators.find((s) => s.userID === userID);
+			const user = player ?? spectator;
 			if (!user) return;
+			const role = player ? "player" : "spectator";
 			Alert.fire({
 				title: "Are you sure?",
-				text: `Do you want to remove player '${user.userName}' from the session? They'll still be able to rejoin if they want.`,
+				text: `Do you want to remove ${role} '${user.userName}' from the session? They'll still be able to rejoin if they want.`,
 				icon: "warning",
 				showCancelButton: true,
 				confirmButtonColor: ButtonColor.Critical,
 				cancelButtonColor: ButtonColor.Safe,
-				confirmButtonText: "Remove player",
+				confirmButtonText: `Remove ${role}`,
 			}).then((result) => {
 				if (result.value) {
 					this.socket.emit("removePlayer", userID);
@@ -3666,6 +3667,23 @@ export default defineComponent({
 				} else {
 					this.spectateKey = r.spectateKey;
 					if (this.allowSpectators && this.spectateKey) this.spectatorLinkToClipboard();
+				}
+			});
+		},
+		disableSpectating() {
+			if (this.userID !== this.sessionOwner) return;
+			Alert.fire({
+				title: "Disable spectating?",
+				text: "All current spectators will be removed from the session and the spectator link will stop working.",
+				icon: "warning",
+				showCancelButton: true,
+				confirmButtonColor: ButtonColor.Critical,
+				cancelButtonColor: ButtonColor.Safe,
+				confirmButtonText: "Disable spectating",
+			}).then((result) => {
+				if (result.value) {
+					this.allowSpectators = false;
+					this.onAllowSpectatorsChange();
 				}
 			});
 		},

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -344,7 +344,7 @@ export default defineComponent({
 			// Session settings
 			ownerIsPlayer: true,
 			allowSpectators: false,
-			spectateKey: undefined as string | undefined,
+			spectateKey: null as string | null,
 			isPublic: false,
 			description: "",
 			ignoreCollections: true,
@@ -3665,7 +3665,7 @@ export default defineComponent({
 				if (r.error) {
 					Alert.fire(r.error);
 				} else {
-					this.spectateKey = r.spectateKey;
+					this.spectateKey = r.spectateKey ?? null;
 					if (this.allowSpectators && this.spectateKey) this.spectatorLinkToClipboard();
 				}
 			});

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -298,7 +298,6 @@ export default defineComponent({
 		if (sessionID) query.sessionID = sessionID; // Note: Setting sessionID to undefined will send it as the "undefined" string, and that's not what we want...
 		const urlParamSpectate = urlParams.get("spectate");
 		if (urlParamSpectate) query.spectate = urlParamSpectate;
-		const spectateUrlKey = urlParamSpectate && sessionID ? { key: urlParamSpectate, sessionID: sessionID } : null;
 
 		// Socket Setup
 		const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io({
@@ -336,7 +335,6 @@ export default defineComponent({
 			// Session status
 			managed: false, // Is the session managed by the server? (i.e. the session doesn't have an owner)
 			sessionID: sessionID,
-			spectateUrlKey: spectateUrlKey,
 			sessionOwner: (sessionID ? userID : undefined) as UserID | undefined,
 			sessionOwnerUsername: userName as string,
 			sessionUsers: [] as SessionUser[],
@@ -3810,11 +3808,11 @@ export default defineComponent({
 			}
 		},
 		updateURLQuery(): void {
+			// Spectate connections keep the invite link as-is so a refresh re-validates it
+			if (this.socket?.io.opts.query?.spectate) return;
 			if (this.sessionID) {
 				const params = new URLSearchParams();
 				params.append("session", this.sessionID);
-				if (this.spectateUrlKey?.sessionID === this.sessionID)
-					params.append("spectate", this.spectateUrlKey.key);
 				history.replaceState({ sessionID: this.sessionID }, "", `/?${params.toString()}`);
 			}
 		},
@@ -4205,6 +4203,11 @@ export default defineComponent({
 	},
 	watch: {
 		sessionID() {
+			// A spectate connection is bound to a single session, moving to another one means rejoining as a player
+			if (this.socket?.io.opts.query?.spectate) {
+				window.location.assign(`/?session=${encodeURIComponent(this.sessionID ?? "")}`);
+				return;
+			}
 			if (this.socket) {
 				let sessionSettings = {};
 				const storedSessionSettings = localStorage.getItem(localStorageSessionSettingsKey);

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -3827,7 +3827,7 @@ export default defineComponent({
 		},
 		updateURLQuery(): void {
 			// Spectate connections keep the invite link as-is so a refresh re-validates it
-			if (this.socket?.io.opts.query?.spectate) return;
+			if (this.isSpectator) return;
 			if (this.sessionID) {
 				const params = new URLSearchParams();
 				params.append("session", this.sessionID);
@@ -4114,7 +4114,7 @@ export default defineComponent({
 		},
 
 		isSpectator(): boolean {
-			return this.sessionSpectators.some((s) => s.userID === this.userID);
+			return !!this.socket?.io.opts.query?.spectate;
 		},
 
 		chatPlaceholder(): string {
@@ -4222,7 +4222,7 @@ export default defineComponent({
 	watch: {
 		sessionID() {
 			// A spectate connection is bound to a single session, moving to another one means rejoining as a player
-			if (this.socket?.io.opts.query?.spectate) {
+			if (this.isSpectator) {
 				window.location.assign(`/?session=${encodeURIComponent(this.sessionID ?? "")}`);
 				return;
 			}

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -543,10 +543,13 @@ export default defineComponent({
 
 			this.socket.on("chatMessage", (message) => {
 				this.messagesHistory.push(message);
-				const bubbleEl = document.querySelector("#chat-bubble-" + message.author);
+				const spectator = this.sessionSpectators.find((s) => s.userID === message.author);
+				const bubbleEl = spectator
+					? document.querySelector("#chat-bubble-spectators")
+					: document.querySelector("#chat-bubble-" + message.author);
 				if (bubbleEl && !this.mutedUsers.has(message.author)) {
 					const bubble = bubbleEl as HTMLElement & { timeoutHandler: number };
-					bubble.innerText = message.text;
+					bubble.innerText = spectator ? `${spectator.userName}: ${message.text}` : message.text;
 					bubble.style.opacity = "1";
 					if (bubble.timeoutHandler) clearTimeout(bubble.timeoutHandler);
 					bubble.timeoutHandler = window.setTimeout(() => (bubble.style.opacity = "0"), 5000);
@@ -4096,6 +4099,10 @@ export default defineComponent({
 
 		isSpectator(): boolean {
 			return this.sessionSpectators.some((s) => s.userID === this.userID);
+		},
+
+		chatPlaceholder(): string {
+			return this.isSpectator && this.drafting ? "Chat with spectators." : "Chat with players in your session.";
 		},
 
 		// Locally displayed spectator list, with the current user first

--- a/client/src/App.ts
+++ b/client/src/App.ts
@@ -2,7 +2,13 @@ import type { ClientToServerEvents, LoaderOptions, ServerToClientEvents } from "
 import type { UserID } from "@/IDTypes";
 import type { SetCode, IIndexable, Language } from "@/Types";
 import { PassingOrder } from "./common";
-import { DistributionMode, DraftLogRecipients, ReadyState, UserData } from "../../src/Session/SessionTypes";
+import {
+	DistributionMode,
+	DraftLogRecipients,
+	ReadyState,
+	SpectatorData,
+	UserData,
+} from "../../src/Session/SessionTypes";
 import { ArenaID, Card, CardID, DeckList, PlainCollection, UniqueCard, UniqueCardID } from "@/CardTypes";
 import type { DraftLog } from "@/DraftLog";
 import type { BotScores } from "@/Bot";
@@ -290,6 +296,9 @@ export default defineComponent({
 			sessionSettings: JSON.stringify(storedSessionSettings),
 		};
 		if (sessionID) query.sessionID = sessionID; // Note: Setting sessionID to undefined will send it as the "undefined" string, and that's not what we want...
+		const urlParamSpectate = urlParams.get("spectate");
+		if (urlParamSpectate) query.spectate = urlParamSpectate;
+		const spectateUrlKey = urlParamSpectate && sessionID ? { key: urlParamSpectate, sessionID: sessionID } : null;
 
 		// Socket Setup
 		const socket: Socket<ServerToClientEvents, ClientToServerEvents> = io({
@@ -327,12 +336,17 @@ export default defineComponent({
 			// Session status
 			managed: false, // Is the session managed by the server? (i.e. the session doesn't have an owner)
 			sessionID: sessionID,
+			spectateUrlKey: spectateUrlKey,
 			sessionOwner: (sessionID ? userID : undefined) as UserID | undefined,
 			sessionOwnerUsername: userName as string,
 			sessionUsers: [] as SessionUser[],
+			sessionSpectators: [] as SpectatorData[],
+			displaySpectatorsList: false,
 			disconnectedUsers: {} as { [uid: UserID]: { userName: string } },
 			// Session settings
 			ownerIsPlayer: true,
+			allowSpectators: false,
+			spectateKey: undefined as string | undefined,
 			isPublic: false,
 			description: "",
 			ignoreCollections: true,
@@ -570,6 +584,10 @@ export default defineComponent({
 				this.userOrder = users.map((u) => u.userID);
 			});
 
+			this.socket.on("sessionSpectators", (spectators) => {
+				this.sessionSpectators = spectators;
+			});
+
 			this.socket.on("userDisconnected", (data) => {
 				if (!this.drafting) return;
 				this.sessionOwner = data.owner;
@@ -586,6 +604,9 @@ export default defineComponent({
 				if (!user) {
 					if (data.userID === this.sessionOwner && data.updatedProperties.userName)
 						this.sessionOwnerUsername = data.updatedProperties.userName;
+					const spectator = this.sessionSpectators.find((s) => s.userID === data.userID);
+					if (spectator && data.updatedProperties.userName)
+						spectator.userName = data.updatedProperties.userName;
 					return;
 				}
 
@@ -3085,7 +3106,9 @@ export default defineComponent({
 		},
 		removePlayer(userID: UserID) {
 			if (this.userID !== this.sessionOwner) return;
-			const user = this.sessionUsers.find((u) => u.userID === userID);
+			const user =
+				this.sessionUsers.find((u) => u.userID === userID) ??
+				this.sessionSpectators.find((s) => s.userID === userID);
 			if (!user) return;
 			Alert.fire({
 				title: "Are you sure?",
@@ -3634,6 +3657,26 @@ export default defineComponent({
 			);
 			fireToast("success", "Session link copied to clipboard!");
 		},
+		onAllowSpectatorsChange() {
+			if (this.userID !== this.sessionOwner || !this.socket) return;
+			this.socket.emit("setAllowSpectators", this.allowSpectators, (r) => {
+				if (r.error) {
+					Alert.fire(r.error);
+				} else {
+					this.spectateKey = r.spectateKey;
+					if (this.allowSpectators && this.spectateKey) this.spectatorLinkToClipboard();
+				}
+			});
+		},
+		spectatorLinkToClipboard() {
+			if (!this.spectateKey) return;
+			copyToClipboard(
+				`${window.location.protocol}//${window.location.hostname}${
+					window.location.port ? ":" + window.location.port : ""
+				}/?session=${encodeURIComponent(this.sessionID ?? "")}&spectate=${encodeURIComponent(this.spectateKey)}`
+			);
+			fireToast("success", "Spectator link copied to clipboard!");
+		},
 		disconnectedReminder() {
 			fireToast("error", "Disconnected from server!");
 		},
@@ -3767,6 +3810,8 @@ export default defineComponent({
 			if (this.sessionID) {
 				const params = new URLSearchParams();
 				params.append("session", this.sessionID);
+				if (this.spectateUrlKey?.sessionID === this.sessionID)
+					params.append("spectate", this.spectateUrlKey.key);
 				history.replaceState({ sessionID: this.sessionID }, "", `/?${params.toString()}`);
 			}
 		},
@@ -4047,6 +4092,17 @@ export default defineComponent({
 			const r: { [uid: UserID]: SessionUser } = {};
 			for (const u of this.sessionUsers) r[u.userID] = u;
 			return r;
+		},
+
+		isSpectator(): boolean {
+			return this.sessionSpectators.some((s) => s.userID === this.userID);
+		},
+
+		// Locally displayed spectator list, with the current user first
+		sortedSessionSpectators(): SpectatorData[] {
+			return [...this.sessionSpectators].sort(
+				(a, b) => (b.userID === this.userID ? 1 : 0) - (a.userID === this.userID ? 1 : 0)
+			);
 		},
 
 		pageTitle(): string {

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -2071,7 +2071,6 @@
 									v-tooltip="'Copy spectator link to clipboard'"
 								>
 									<font-awesome-icon icon="fa-solid fa-clipboard" />
-									<code style="margin-left: 0.3em">{{ spectateKey }}</code>
 								</span>
 							</div>
 						</div>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -620,35 +620,44 @@
 						<span>{{ sessionSpectators.length }}</span>
 						<font-awesome-icon icon="fa-solid fa-chevron-down" class="spectator-caret" />
 					</span>
-					<div class="spectators-dropdown" v-if="displaySpectatorsList" @click.stop>
-						<div
-							class="spectator-name"
-							:class="{ self: spectator.userID === userID }"
-							v-for="spectator in sortedSessionSpectators"
-							:key="spectator.userID"
-						>
-							<font-awesome-icon
-								v-if="userID === sessionOwner"
-								icon="fa-solid fa-user-slash"
-								class="clickable red"
-								v-tooltip="`Remove ${spectator.userName} from the session`"
-								@click="removePlayer(spectator.userID)"
-							/>
-							<span class="spectator-username">{{ spectator.userName }}</span>
+					<Transition>
+						<div class="spectators-dropdown" v-if="displaySpectatorsList" @click.stop>
+							<div class="game-modes-cat-title">Spectators</div>
+							<div class="spectator-list">
+								<div
+									class="spectator-name"
+									:class="{ self: spectator.userID === userID }"
+									v-for="spectator in sortedSessionSpectators"
+									:key="spectator.userID"
+								>
+									<font-awesome-icon
+										v-if="userID === sessionOwner"
+										icon="fa-solid fa-user-slash"
+										class="clickable red"
+										v-tooltip="`Remove ${spectator.userName} from the session`"
+										@click="removePlayer(spectator.userID)"
+									/>
+									<span class="spectator-username">{{ spectator.userName }}</span>
+								</div>
+								<div v-if="sessionSpectators.length === 0">No spectators</div>
+							</div>
+							<div class="spectator-controls" v-if="userID === sessionOwner">
+								<hr />
+								<!-- NOTE: If the owner changes after spectating was enabled, the new owner won't know the spectator key.
+										We could send it, but for now let's avoid leaking the key on owner disconnection. -->
+								<button @click="spectatorLinkToClipboard" :disabled="!spectateKey">
+									<font-awesome-icon icon="fa-solid fa-clipboard" /> Copy Link
+								</button>
+								<button
+									class="stop"
+									v-tooltip="'Removes every spectator and invalidates the link'"
+									@click="disableSpectating"
+								>
+									<font-awesome-icon icon="fa-regular fa-eye-slash" /> Disable
+								</button>
+							</div>
 						</div>
-						<div class="spectator-controls" v-if="userID === sessionOwner">
-							<button @click="spectatorLinkToClipboard">
-								<font-awesome-icon icon="fa-solid fa-clipboard" /> Copy Link
-							</button>
-							<button
-								class="stop"
-								v-tooltip="'Removes every spectator and invalidates the link'"
-								@click="disableSpectating"
-							>
-								<font-awesome-icon icon="fa-regular fa-eye-slash" /> Disable
-							</button>
-						</div>
-					</div>
+					</Transition>
 					<div class="chat-bubble" id="chat-bubble-spectators"></div>
 				</div>
 			</div>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -629,9 +629,9 @@
 								v-tooltip="`Remove ${spectator.userName} from the session`"
 								@click="removePlayer(spectator.userID)"
 							/>
-							<div class="chat-bubble" :id="'chat-bubble-' + spectator.userID"></div>
 						</div>
 					</div>
+					<div class="chat-bubble" id="chat-bubble-spectators"></div>
 				</div>
 			</div>
 			<div class="player-list-container">
@@ -706,12 +706,7 @@
 			</div>
 			<div class="chat">
 				<form @submit.prevent="sendChatMessage">
-					<input
-						type="text"
-						v-model="currentChatMessage"
-						placeholder="Chat with players in your session."
-						maxlength="255"
-					/>
+					<input type="text" v-model="currentChatMessage" :placeholder="chatPlaceholder" maxlength="255" />
 				</form>
 				<font-awesome-icon
 					class="clickable"
@@ -727,6 +722,7 @@
 					:sessionOwner="sessionOwner"
 					:sessionOwnerUsername="sessionOwnerUsername"
 					:userByID="userByID"
+					:sessionSpectators="sessionSpectators"
 					:mutedUsers="mutedUsers"
 				/>
 			</div>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -607,13 +607,19 @@
 					<font-awesome-icon icon="fa-solid fa-random" />
 				</div>
 				<div
-					v-if="sessionSpectators.length > 0"
+					v-if="sessionSpectators.length > 0 || (userID === sessionOwner && allowSpectators)"
 					class="session-spectators clickable"
 					@click="displaySpectatorsList = !displaySpectatorsList"
-					v-tooltip="`${sessionSpectators.length} spectator(s)`"
 				>
-					<font-awesome-icon icon="fa-regular fa-eye" />
-					<span>{{ sessionSpectators.length }}</span>
+					<span
+						class="spectator-count"
+						:class="{ open: displaySpectatorsList }"
+						v-tooltip="`${sessionSpectators.length} spectator(s)`"
+					>
+						<font-awesome-icon icon="fa-regular fa-eye" />
+						<span>{{ sessionSpectators.length }}</span>
+						<font-awesome-icon icon="fa-solid fa-chevron-down" class="spectator-caret" />
+					</span>
 					<div class="spectators-dropdown" v-if="displaySpectatorsList" @click.stop>
 						<div
 							class="spectator-name"
@@ -621,7 +627,6 @@
 							v-for="spectator in sortedSessionSpectators"
 							:key="spectator.userID"
 						>
-							{{ spectator.userName }}
 							<font-awesome-icon
 								v-if="userID === sessionOwner"
 								icon="fa-solid fa-user-slash"
@@ -629,6 +634,19 @@
 								v-tooltip="`Remove ${spectator.userName} from the session`"
 								@click="removePlayer(spectator.userID)"
 							/>
+							<span class="spectator-username">{{ spectator.userName }}</span>
+						</div>
+						<div class="spectator-controls" v-if="userID === sessionOwner">
+							<button @click="spectatorLinkToClipboard">
+								<font-awesome-icon icon="fa-solid fa-clipboard" /> Copy Link
+							</button>
+							<button
+								class="stop"
+								v-tooltip="'Removes every spectator and invalidates the link'"
+								@click="disableSpectating"
+							>
+								<font-awesome-icon icon="fa-regular fa-eye-slash" /> Disable
+							</button>
 						</div>
 					</div>
 					<div class="chat-bubble" id="chat-bubble-spectators"></div>

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -606,6 +606,33 @@
 				>
 					<font-awesome-icon icon="fa-solid fa-random" />
 				</div>
+				<div
+					v-if="sessionSpectators.length > 0"
+					class="session-spectators clickable"
+					@click="displaySpectatorsList = !displaySpectatorsList"
+					v-tooltip="`${sessionSpectators.length} spectator(s)`"
+				>
+					<font-awesome-icon icon="fa-regular fa-eye" />
+					<span>{{ sessionSpectators.length }}</span>
+					<div class="spectators-dropdown" v-if="displaySpectatorsList" @click.stop>
+						<div
+							class="spectator-name"
+							:class="{ self: spectator.userID === userID }"
+							v-for="spectator in sortedSessionSpectators"
+							:key="spectator.userID"
+						>
+							{{ spectator.userName }}
+							<font-awesome-icon
+								v-if="userID === sessionOwner"
+								icon="fa-solid fa-user-slash"
+								class="clickable red"
+								v-tooltip="`Remove ${spectator.userName} from the session`"
+								@click="removePlayer(spectator.userID)"
+							/>
+							<div class="chat-bubble" :id="'chat-bubble-' + spectator.userID"></div>
+						</div>
+					</div>
+				</div>
 			</div>
 			<div class="player-list-container">
 				<template v-if="!drafting">
@@ -1121,9 +1148,7 @@
 				</div>
 				<transition name="fade">
 					<div
-						v-if="
-							draftPaused && !waitingForDisconnectedUsers && !(userID === sessionOwner && !ownerIsPlayer)
-						"
+						v-if="draftPaused && !waitingForDisconnectedUsers && gameState !== GameState.Watching"
 						class="disconnected-user-popup-container"
 					>
 						<div class="disconnected-user-popup">
@@ -2004,6 +2029,36 @@
 									:false-value="true"
 									id="is-owner-player"
 								/>
+							</div>
+						</div>
+						<div
+							class="line"
+							v-tooltip.left="{
+								popperClass: 'option-tooltip',
+								content: `<p>Let users watch the game without participating.</p>
+								<p>Enabling this generates a spectator link and copies it to your clipboard. Anyone opening the link joins the session as a spectator, even while a game is in progress.</p>
+								<p>Spectators see the picks of each player as they happen.</p>`,
+								html: true,
+							}"
+						>
+							<label for="allow-spectators">Allow Spectators</label>
+							<div class="right">
+								<input
+									type="checkbox"
+									v-model="allowSpectators"
+									id="allow-spectators"
+									@change="onAllowSpectatorsChange"
+								/>
+								<span
+									v-if="allowSpectators && spectateKey"
+									class="clickable"
+									style="margin-left: 0.5em"
+									@click="spectatorLinkToClipboard"
+									v-tooltip="'Copy spectator link to clipboard'"
+								>
+									<font-awesome-icon icon="fa-solid fa-clipboard" />
+									<code style="margin-left: 0.3em">{{ spectateKey }}</code>
+								</span>
 							</div>
 						</div>
 						<div class="line">

--- a/client/src/components/ChatHistory.vue
+++ b/client/src/components/ChatHistory.vue
@@ -25,13 +25,7 @@
 							/>
 						</template>
 					</template>
-					{{
-						msg.author in userByID
-							? userByID[msg.author].userName
-							: msg.author === sessionOwner && sessionOwnerUsername
-								? sessionOwnerUsername
-								: "(Left)"
-					}}
+					{{ authorName(msg.author) }}
 				</span>
 				<span class="chat-system" v-else>{{ new Date(msg.timestamp).toLocaleTimeString() }}</span>
 				<span class="chat-message">
@@ -46,7 +40,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { UserData } from "../../../src/Session/SessionTypes";
+import { SpectatorData, UserData } from "../../../src/Session/SessionTypes";
 
 const props = defineProps<{
 	messagesHistory: {
@@ -58,10 +52,19 @@ const props = defineProps<{
 	sessionOwner: string;
 	sessionOwnerUsername: string;
 	userByID: Record<string, UserData>;
+	sessionSpectators: SpectatorData[];
 	mutedUsers: Set<string>;
 }>();
 
 const reversedMessages = computed(() => props.messagesHistory.slice().reverse());
+
+const authorName = (author: string) => {
+	if (author in props.userByID) return props.userByID[author].userName;
+	const spectator = props.sessionSpectators.find((s) => s.userID === author);
+	if (spectator) return spectator.userName;
+	if (author === props.sessionOwner && props.sessionOwnerUsername) return props.sessionOwnerUsername;
+	return "(Left)";
+};
 </script>
 
 <style scoped>

--- a/client/src/css/app.css
+++ b/client/src/css/app.css
@@ -1427,9 +1427,30 @@ ul.player-list {
 	position: relative;
 	display: flex;
 	align-items: center;
-	gap: 0.2em;
 	font-size: 0.8em;
 	margin-right: 0.5em;
+}
+
+.session-spectators .spectator-count {
+	display: flex;
+	align-items: center;
+	gap: 0.2em;
+	padding: 0.2em 0.2em 0.2em 0.35em;
+	border-radius: 0.4em;
+}
+
+.session-spectators .spectator-count:hover,
+.session-spectators .spectator-count.open {
+	background: #282828;
+}
+
+.spectator-count .spectator-caret {
+	font-size: 0.8em;
+	transition: transform 0.2s;
+}
+
+.spectator-count.open .spectator-caret {
+	transform: rotate(180deg);
 }
 
 .session-spectators .chat-bubble {
@@ -1441,13 +1462,14 @@ ul.player-list {
 
 .spectators-dropdown {
 	position: absolute;
-	top: 100%;
+	top: calc(100% + 0.75em);
 	left: 0;
 	z-index: 10;
 	display: flex;
 	flex-direction: column;
 	gap: 0.4em;
-	min-width: 12em;
+	min-width: 11em;
+	max-width: 13em;
 	padding: 0.5em;
 	background: #282828;
 	border-radius: 0.5em;
@@ -1460,17 +1482,27 @@ ul.player-list {
 	position: relative;
 	display: flex;
 	align-items: center;
-	gap: 0.3em;
-	max-width: 12em;
-	overflow: hidden;
+	gap: 0.6em;
 	white-space: nowrap;
-	font-size: 0.8em;
+	font-size: 0.9em;
 	color: #aaa;
 }
 
+.spectators-dropdown .spectator-username {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .spectators-dropdown .spectator-name.self {
-	font-size: 1em;
 	color: inherit;
+	font-weight: 600;
+}
+
+.spectators-dropdown .spectator-controls {
+	display: flex;
+	flex-direction: column;
+	padding-top: 0.3em;
+	border-top: 1px solid #555;
 }
 
 .loading {

--- a/client/src/css/app.css
+++ b/client/src/css/app.css
@@ -1429,45 +1429,50 @@ ul.player-list {
 	align-items: center;
 	font-size: 0.8em;
 	margin-right: 0.5em;
-}
+	user-select: none;
 
-.session-spectators .spectator-count {
-	display: flex;
-	align-items: center;
-	gap: 0.2em;
-	padding: 0.2em 0.2em 0.2em 0.35em;
-	border-radius: 0.4em;
-}
+	.spectator-count {
+		display: flex;
+		align-items: center;
+		gap: 0.2em;
+		padding: 0.2em 0.2em 0.2em 0.35em;
+		border-radius: 0.4em;
 
-.session-spectators .spectator-count:hover,
-.session-spectators .spectator-count.open {
-	background: #282828;
-}
+		&:hover,
+		&.open {
+			background-color: #282828;
+		}
 
-.spectator-count .spectator-caret {
-	font-size: 0.8em;
-	transition: transform 0.2s;
-}
+		.spectator-caret {
+			position: absolute;
+			bottom: -4px;
+			left: calc(50% - 0.5em);
 
-.spectator-count.open .spectator-caret {
-	transform: rotate(180deg);
-}
+			font-size: 0.8em;
+			transition: transform 0.2s;
+			transform-origin: center center;
+		}
 
-.session-spectators .chat-bubble {
-	top: calc(100% + 1.5em);
-	left: 0;
-	width: max-content;
-	font-size: 1.25em;
+		&.open .spectator-caret {
+			transform: rotate(180deg) translateY(-2px);
+		}
+	}
+
+	.chat-bubble {
+		top: calc(100% + 1.5em);
+		left: 0;
+		width: max-content;
+		font-size: 1.25em;
+	}
 }
 
 .spectators-dropdown {
 	position: absolute;
 	top: calc(100% + 0.75em);
 	left: 0;
-	z-index: 10;
+	z-index: 2;
 	display: flex;
 	flex-direction: column;
-	gap: 0.4em;
 	min-width: 11em;
 	max-width: 13em;
 	padding: 0.5em;
@@ -1476,33 +1481,60 @@ ul.player-list {
 	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.5);
 	cursor: default;
 	font-size: 1.25em;
-}
 
-.spectators-dropdown .spectator-name {
-	position: relative;
-	display: flex;
-	align-items: center;
-	gap: 0.6em;
-	white-space: nowrap;
-	font-size: 0.9em;
-	color: #aaa;
-}
+	hr {
+		width: 90%;
+	}
 
-.spectators-dropdown .spectator-username {
-	overflow: hidden;
-	text-overflow: ellipsis;
-}
+	.spectator-list {
+		font-size: 0.9em;
+		color: #aaa;
 
-.spectators-dropdown .spectator-name.self {
-	color: inherit;
-	font-weight: 600;
-}
+		.spectator-name {
+			position: relative;
+			display: flex;
+			align-items: center;
+			gap: 0.6em;
+			white-space: nowrap;
 
-.spectators-dropdown .spectator-controls {
-	display: flex;
-	flex-direction: column;
-	padding-top: 0.3em;
-	border-top: 1px solid #555;
+			.spectator-username {
+				overflow: hidden;
+				text-overflow: ellipsis;
+			}
+
+			&.self {
+				color: inherit;
+				font-weight: 600;
+			}
+		}
+	}
+
+	.spectator-controls {
+		display: flex;
+		flex-direction: column;
+	}
+
+	&:after {
+		content: "";
+		position: absolute;
+		top: -7px;
+		left: 7px;
+		width: 17px;
+		height: 17px;
+		background: #282828;
+		transform: rotate(45deg);
+		z-index: -1;
+	}
+
+	&.v-enter-active,
+	&.v-leave-active {
+		transition: opacity 0.2s ease;
+	}
+
+	&.v-enter-from,
+	&.v-leave-to {
+		opacity: 0;
+	}
 }
 
 .loading {

--- a/client/src/css/app.css
+++ b/client/src/css/app.css
@@ -1423,6 +1423,49 @@ ul.player-list {
 	}
 }
 
+.session-spectators {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 0.2em;
+	font-size: 0.8em;
+	margin-right: 0.5em;
+}
+
+.spectators-dropdown {
+	position: absolute;
+	top: 100%;
+	left: 0;
+	z-index: 10;
+	display: flex;
+	flex-direction: column;
+	gap: 0.4em;
+	min-width: 12em;
+	padding: 0.5em;
+	background: #282828;
+	border-radius: 0.5em;
+	box-shadow: 0 3px 6px rgba(0, 0, 0, 0.5);
+	cursor: default;
+	font-size: 1.25em;
+}
+
+.spectators-dropdown .spectator-name {
+	position: relative;
+	display: flex;
+	align-items: center;
+	gap: 0.3em;
+	max-width: 12em;
+	overflow: hidden;
+	white-space: nowrap;
+	font-size: 0.8em;
+	color: #aaa;
+}
+
+.spectators-dropdown .spectator-name.self {
+	font-size: 1em;
+	color: inherit;
+}
+
 .loading {
 	position: fixed;
 	z-index: 999;

--- a/client/src/css/app.css
+++ b/client/src/css/app.css
@@ -1432,6 +1432,13 @@ ul.player-list {
 	margin-right: 0.5em;
 }
 
+.session-spectators .chat-bubble {
+	top: calc(100% + 1.5em);
+	left: 0;
+	width: max-content;
+	font-size: 1.25em;
+}
+
 .spectators-dropdown {
 	position: absolute;
 	top: 100%;

--- a/src/Persistence.ts
+++ b/src/Persistence.ts
@@ -121,9 +121,12 @@ async function loadSavedSessions() {
 
 export function restoreSession(s: any, owner: UserID) {
 	const r = new Session(s.id, owner);
-	for (const prop of Object.getOwnPropertyNames(s).filter((p) => !["draftState", "owner"].includes(p))) {
+	for (const prop of Object.getOwnPropertyNames(s).filter(
+		(p) => !["draftState", "owner", "spectators"].includes(p)
+	)) {
 		(r as IIndexable)[prop] = s[prop];
 	}
+	r.spectators = new Set(s.spectators ?? []);
 
 	if (s.draftState) {
 		switch (s.draftState.type) {
@@ -233,10 +236,11 @@ export function getPoDSession(s: Session) {
 	const PoDSession: Record<string, any> = {};
 
 	for (const prop of Object.getOwnPropertyNames(s).filter(
-		(p) => !["users", "draftState", "sendDecklogTimeout"].includes(p)
+		(p) => !["users", "spectators", "draftState", "sendDecklogTimeout"].includes(p)
 	)) {
 		if (!((s as IIndexable)[prop] instanceof Function)) PoDSession[prop] = (s as IIndexable)[prop];
 	}
+	PoDSession.spectators = [...s.spectators];
 
 	if (s.drafting) {
 		PoDSession.disconnectedUsers = structuredClone(s.disconnectedUsers); // Avoid modifying the original

--- a/src/Persistence.ts
+++ b/src/Persistence.ts
@@ -126,7 +126,6 @@ export function restoreSession(s: any, owner: UserID) {
 	)) {
 		(r as IIndexable)[prop] = s[prop];
 	}
-	r.spectators = new Set(s.spectators ?? []);
 
 	if (s.draftState) {
 		switch (s.draftState.type) {
@@ -240,7 +239,6 @@ export function getPoDSession(s: Session) {
 	)) {
 		if (!((s as IIndexable)[prop] instanceof Function)) PoDSession[prop] = (s as IIndexable)[prop];
 	}
-	PoDSession.spectators = [...s.spectators];
 
 	if (s.drafting) {
 		PoDSession.disconnectedUsers = structuredClone(s.disconnectedUsers); // Avoid modifying the original

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -237,6 +237,7 @@ export class Session implements IIndexable {
 	}
 
 	addSpectator(userID: UserID) {
+		if (!this.allowSpectators) return;
 		Connections[userID].sessionID = this.id;
 		this.spectators.add(userID);
 		this.syncSessionOptions(userID);
@@ -978,18 +979,6 @@ export class Session implements IIndexable {
 		this.drafting = false;
 		this.draftPaused = false;
 		this.disconnectedUsers = {};
-		this.cleanDisconnectedSpectators();
-	}
-
-	// Spectators are kept around while drafting so they can reconnect. Drop the ones that never did
-	cleanDisconnectedSpectators() {
-		let spectatorsChanged = false;
-		for (const uid of [...this.spectators])
-			if (!Connections[uid]) {
-				this.spectators.delete(uid);
-				spectatorsChanged = true;
-			}
-		if (spectatorsChanged) this.broadcastSpectators();
 	}
 
 	///////////////////// Winston Draft //////////////////////

--- a/src/Session.ts
+++ b/src/Session.ts
@@ -74,7 +74,13 @@ import { WinstonDraftState, isWinstonDraftState } from "./WinstonDraft.js";
 import { ServerToClientEvents } from "./SocketType";
 import { Constants, EnglishBasicLandNames } from "./Constants.js";
 import { SessionsSettingsProps } from "./Session/SessionProps.js";
-import { DistributionMode, DraftLogRecipients, DisconnectedUser, UserData } from "./Session/SessionTypes.js";
+import {
+	DistributionMode,
+	DraftLogRecipients,
+	DisconnectedUser,
+	SpectatorData,
+	UserData,
+} from "./Session/SessionTypes.js";
 import { IIndexable, SetCode } from "./Types.js";
 import { isRotisserieDraftState, RotisserieDraftStartOptions, RotisserieDraftState } from "./RotisserieDraft.js";
 import { parseLine } from "./parseCardList.js";
@@ -126,9 +132,12 @@ export class Session implements IIndexable {
 	readonly managed: boolean = false;
 	userOrder: Array<string> = [];
 	users: Set<UserID> = new Set();
+	spectators: Set<UserID> = new Set();
 
 	// Options
 	ownerIsPlayer: boolean = true;
+	allowSpectators: boolean = false;
+	spectateKey?: string = undefined;
 	setRestriction: Array<string> = [Constants.MTGASets[Constants.MTGASets.length - 1]];
 	isPublic: boolean = false;
 	description: string = "";
@@ -225,6 +234,44 @@ export class Session implements IIndexable {
 			this.userOrder.splice(Math.floor(Math.random() * (this.userOrder.length + 1)), 0, userID);
 		this.notifyUserChange();
 		this.syncSessionOptions(userID);
+	}
+
+	addSpectator(userID: UserID) {
+		Connections[userID].sessionID = this.id;
+		this.spectators.add(userID);
+		this.syncSessionOptions(userID);
+		this.notifyUserChange();
+		if (this.drafting && isDraftState(this.draftState)) {
+			Connections[userID].socket.emit("startDraft", this.getSortedVirtualPlayerData());
+			Connections[userID].socket.emit("draftState", {
+				booster: [],
+				boosterCount: 0,
+				pickNumber: 0,
+				picksThisRound: 0,
+				burnsThisRound: 0,
+				skipPick: true,
+
+				boosterNumber: this.draftState.boosterNumber,
+			});
+			Connections[userID].socket.emit("draftLogLive", { log: this.draftLog });
+		}
+	}
+
+	removeSpectator(userID: UserID) {
+		if (!this.spectators.delete(userID)) return;
+		if (Connections[userID]?.sessionID === this.id) Connections[userID].sessionID = undefined;
+		this.broadcastSpectators();
+	}
+
+	getSpectatorData() {
+		const spectatorData: SpectatorData[] = [];
+		for (const uid of this.spectators)
+			if (Connections[uid]) spectatorData.push({ userID: uid, userName: Connections[uid].userName });
+		return spectatorData;
+	}
+
+	broadcastSpectators() {
+		this.emitToConnectedUsers("sessionSpectators", this.getSpectatorData());
 	}
 
 	setSessionOwner(newOwnerID: UserID) {
@@ -508,6 +555,7 @@ export class Session implements IIndexable {
 			bracket: this.bracket,
 		};
 		for (const p of Object.keys(SessionsSettingsProps)) options[p] = (this as IIndexable)[p];
+		if (userID === this.owner) options.spectateKey = this.spectateKey;
 		Connections[userID]?.socket.emit("sessionOptions", options);
 	}
 
@@ -912,12 +960,14 @@ export class Session implements IIndexable {
 		}
 
 		// Send to all session users
+		const spectatorData = this.getSpectatorData();
 		this.forUsers((uid) => {
 			Connections[uid]?.socket.emit(
 				"sessionOwner",
 				this.owner,
 				this.owner && this.owner in Connections ? Connections[this.owner].userName : null
 			);
+			Connections[uid]?.socket.emit("sessionSpectators", spectatorData);
 			Connections[uid]?.socket.emit("sessionUsers", userInfo);
 		});
 	}
@@ -928,6 +978,18 @@ export class Session implements IIndexable {
 		this.drafting = false;
 		this.draftPaused = false;
 		this.disconnectedUsers = {};
+		this.cleanDisconnectedSpectators();
+	}
+
+	// Spectators are kept around while drafting so they can reconnect. Drop the ones that never did
+	cleanDisconnectedSpectators() {
+		let spectatorsChanged = false;
+		for (const uid of [...this.spectators])
+			if (!Connections[uid]) {
+				this.spectators.delete(uid);
+				spectatorsChanged = true;
+			}
+		if (spectatorsChanged) this.broadcastSpectators();
 	}
 
 	///////////////////// Winston Draft //////////////////////
@@ -1919,6 +1981,8 @@ export class Session implements IIndexable {
 					log: this.draftLog,
 				});
 		}
+		this.toSpectators("startDraft", virtualPlayerData);
+		this.toSpectators("draftLogLive", { log: this.draftLog });
 
 		this.distributeBoosters();
 		return new SocketAck();
@@ -2355,18 +2419,21 @@ export class Session implements IIndexable {
 		if (burnedCards) cardsToRemove = cardsToRemove.concat(burnedCards);
 		cardsToRemove.sort((a, b) => b - a); // Remove last index first to avoid shifting indices
 
-		// Update draft log for live display if owner in not playing (Do this before removing the cards, damnit!)
-		if (this.owner && this.shouldSendLiveUpdates()) {
-			Connections[this.owner].socket.emit("draftLogLive", {
-				userID: userID,
-				pick: pickData,
-			});
-			this.updateDecklist(userID);
-			Connections[this.owner].socket.emit("pickAlert", {
+		// Update draft log for live display if anyone is watching (Do this before removing the cards, damnit!)
+		if ((this.owner && this.shouldSendLiveUpdates()) || this.spectators.size > 0) {
+			const pickUpdate = { userID: userID, pick: pickData };
+			const pickAlert = {
 				userID: userID,
 				userName: Connections[userID].userName,
 				cards: pickedCards.map((idx) => booster[idx]),
-			});
+			};
+			this.updateDecklist(userID);
+			if (this.owner && this.shouldSendLiveUpdates()) {
+				Connections[this.owner].socket.emit("draftLogLive", pickUpdate);
+				Connections[this.owner].socket.emit("pickAlert", pickAlert);
+			}
+			this.toSpectators("draftLogLive", pickUpdate);
+			this.toSpectators("pickAlert", pickAlert);
 		}
 
 		if (s.players[userID].effect?.aetherSearcher) {
@@ -2756,17 +2823,19 @@ export class Session implements IIndexable {
 				++boosterIndex;
 			}
 
-			if (this.owner && !this.ownerIsPlayer)
-				Connections[this.owner]?.socket.emit("draftState", {
-					booster: [],
-					boosterCount: 0,
-					pickNumber: 0,
-					picksThisRound: 0,
-					burnsThisRound: 0,
-					skipPick: true,
+			const watchingDraftState = {
+				booster: [],
+				boosterCount: 0,
+				pickNumber: 0,
+				picksThisRound: 0,
+				burnsThisRound: 0,
+				skipPick: true,
 
-					boosterNumber: s.boosterNumber,
-				});
+				boosterNumber: s.boosterNumber,
+			};
+			if (this.owner && !this.ownerIsPlayer)
+				Connections[this.owner]?.socket.emit("draftState", watchingDraftState);
+			this.toSpectators("draftState", watchingDraftState);
 		};
 
 		if (this.reviewTimer > 0 && s.boosterNumber > 0) {
@@ -3123,6 +3192,7 @@ export class Session implements IIndexable {
 		};
 
 		if (this.owner && this.shouldSendLiveUpdates()) Connections[this.owner]?.socket.emit("draftLogLive", shareData);
+		this.toSpectators("draftLogLive", shareData);
 
 		if (!this.drafting) {
 			// Note: The session setting draftLogRecipients may have changed since the game ended.
@@ -3349,7 +3419,7 @@ export class Session implements IIndexable {
 
 		this.forUsers((uid) => {
 			this.updateDecklist(uid);
-			Connections[uid].socket.emit("endTeamSealed");
+			Connections[uid]?.socket.emit("endTeamSealed");
 		});
 		console.log(`Session ${this.id} Team Sealed stopped.`);
 	}
@@ -3879,13 +3949,19 @@ export class Session implements IIndexable {
 		this.emitToConnectedUsers("sessionOptions", { bracket: this.bracket });
 	}
 
-	// Execute fn for each user. Owner included even if they're not playing.
+	// Execute fn for each user, including spectators and the owner even when they're not playing.
 	forUsers(fn: (uid: UserID) => void) {
 		if (!this.ownerIsPlayer && this.owner && this.owner in Connections) fn(this.owner);
 		for (const user of this.users) fn(user);
+		for (const uid of this.spectators) fn(uid);
 	}
 	forNonOwners(fn: (uid: UserID) => void) {
 		for (const uid of this.users) if (uid !== this.owner) fn(uid);
+	}
+
+	// Emit to all connected spectators. The non-playing owner is notified separately at each call site.
+	toSpectators<T extends keyof ServerToClientEvents>(eventKey: T, ...args: Parameters<ServerToClientEvents[T]>) {
+		for (const uid of this.spectators) Connections[uid]?.socket.emit(eventKey, ...args);
 	}
 
 	emitToConnectedUsers<T extends keyof ServerToClientEvents>(
@@ -3900,6 +3976,7 @@ export class Session implements IIndexable {
 		...args: Parameters<ServerToClientEvents[T]>
 	) {
 		for (const uid of this.users) if (uid !== this.owner) Connections[uid]?.socket.emit(eventKey, ...args);
+		this.toSpectators(eventKey, ...args);
 	}
 }
 

--- a/src/Session/SessionProps.ts
+++ b/src/Session/SessionProps.ts
@@ -6,6 +6,7 @@ import { DistributionMode, DraftLogRecipients } from "./SessionTypes";
 // Validate session settings types and values.
 export const SessionsSettingsProps: { [propName: string]: (val: unknown) => boolean } = {
 	ownerIsPlayer: isBoolean,
+	allowSpectators: isBoolean,
 	setRestriction(val: unknown): val is SetCode[] {
 		if (!isArrayOf(isString)(val)) return false;
 		for (const s of val)

--- a/src/Session/SessionTypes.ts
+++ b/src/Session/SessionTypes.ts
@@ -17,6 +17,11 @@ export type UserData = {
 	boosterCount?: number;
 };
 
+export type SpectatorData = {
+	userID: UserID;
+	userName: string;
+};
+
 export type DistributionMode = "regular" | "shufflePlayerBoosters" | "shuffleBoosterPool" | "staggered";
 export type DraftLogRecipients = "none" | "owner" | "delayed" | "everyone";
 

--- a/src/SocketType.ts
+++ b/src/SocketType.ts
@@ -2,7 +2,7 @@ import { GridDraftSyncData } from "./GridDraft";
 import { WinstonDraftSyncData } from "./WinstonDraft";
 import { SessionID, UserID } from "./IDTypes";
 import { Message, SocketAck, SocketError } from "./Message";
-import { DistributionMode, DraftLogRecipients, ReadyState, UserData } from "./Session/SessionTypes";
+import { DistributionMode, DraftLogRecipients, ReadyState, SpectatorData, UserData } from "./Session/SessionTypes";
 import { Options } from "./utils";
 import { SetCode } from "./Types";
 import { DraftLog, DraftPick } from "./DraftLog";
@@ -67,6 +67,8 @@ export interface ServerToClientEvents {
 	userDisconnected: (data: { owner?: UserID; disconnectedUsers: { [uid: string]: { userName: string } } }) => void;
 	sessionOptions: (
 		sessionOptions: Partial<{
+			allowSpectators: boolean;
+			spectateKey: string | undefined;
 			boosterContent: { [slot: string]: number };
 			boostersPerPlayer: number;
 			bots: number;
@@ -275,6 +277,8 @@ export interface ServerToClientEvents {
 	choosePlayer: (reason: string, users: UserID[], callback: (user: UserID) => void) => void;
 
 	takeoverVote: (userName: string, callback: (response: boolean | null) => void) => void;
+
+	sessionSpectators: (spectators: SpectatorData[]) => void;
 }
 
 export interface ClientToServerEvents {
@@ -465,6 +469,8 @@ export interface ClientToServerEvents {
 	convertMTGOLog: (str: string, callback: (response: SocketError | DraftLog) => void) => void;
 
 	setHooks: (hooks: Hooks, ack: (result: SocketAck) => void) => void;
+
+	setAllowSpectators: (val: boolean, ack: (result: SocketAck & { spectateKey?: string }) => void) => void;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-empty-object-type

--- a/src/server.ts
+++ b/src/server.ts
@@ -28,6 +28,7 @@ import { InactiveConnections, InactiveSessions, restoreSession, getPoDSession, c
 import { Connection, Connections } from "./Connection.js";
 import { DistributionMode, DraftLogRecipients, ReadyState } from "./Session/SessionTypes";
 import { Session, Sessions, getPublicSessionData } from "./Session.js";
+import { isDraftState } from "./DraftState.js";
 import {
 	CardID,
 	Card,
@@ -327,7 +328,13 @@ function chatMessage(
 	if (!isObject(message) || !isString(message.author) || !isString(message.text) || !isNumber(message.timestamp))
 		return;
 	message.text = message.text.substring(0, Math.min(255, message.text.length)); // Limits chat message length
-	Sessions[sessionID].forUsers((user) => Connections[user]?.socket.emit("chatMessage", message));
+
+	// Spectator messages don't reach the players while a game is in progress
+	const sess = Sessions[sessionID];
+	if (sess.drafting && sess.spectators.has(userID)) {
+		if (sess.owner && !sess.ownerIsPlayer) Connections[sess.owner]?.socket.emit("chatMessage", message);
+		sess.toSpectators("chatMessage", message);
+	} else sess.forUsers((user) => Connections[user]?.socket.emit("chatMessage", message));
 }
 
 function setReady(userID: UserID, sessionID: SessionID, readyState: ReadyState) {
@@ -932,27 +939,30 @@ function setSessionOwner(userID: UserID, sessionID: SessionID, newOwnerID: UserI
 }
 
 function removePlayer(userID: UserID, sessionID: SessionID, userToRemove: UserID) {
-	if (
-		!Sessions[sessionID] ||
-		userToRemove === Sessions[sessionID].owner ||
-		!Sessions[sessionID].users.has(userToRemove)
-	)
-		return;
+	const sess = Sessions[sessionID];
+	if (!sess || userToRemove === sess.owner) return;
 
-	removeUserFromSession(sessionID, userToRemove);
-	Sessions[sessionID].replaceDisconnectedPlayers();
-	Sessions[sessionID].notifyUserChange();
+	if (sess.users.has(userToRemove)) {
+		removeUserFromSession(sessionID, userToRemove);
+		sess.replaceDisconnectedPlayers();
+		sess.notifyUserChange();
+	} else if (sess.spectators.has(userToRemove)) {
+		sess.removeSpectator(userToRemove);
+	} else return;
 
-	if (!Connections[userToRemove])
-		return console.error(`removePlayer: No connection found for userID ${userToRemove}`);
-
-	const newSession = newSessionID();
-	joinSession(newSession, userToRemove);
-	Connections[userToRemove].socket.emit("setSession", newSession);
-	Connections[userToRemove].socket.emit(
-		"message",
+	moveToNewSession(
+		userToRemove,
 		new Message("Removed from session", `You've been removed from session '${sessionID}' by its owner.`)
 	);
+}
+
+function moveToNewSession(userID: UserID, message: Message) {
+	if (!Connections[userID]) return console.error(`moveToNewSession: No connection found for userID ${userID}`);
+
+	const newSession = newSessionID();
+	joinSession(newSession, userID);
+	Connections[userID].socket.emit("setSession", newSession);
+	Connections[userID].socket.emit("message", message);
 }
 function setSeating(userID: UserID, sessionID: SessionID, seating: Array<UserID>) {
 	if (!Sessions[sessionID].setSeating(seating)) Sessions[sessionID].notifyUserChange(); // Something unexpected happened, notify to avoid any potential de-sync.
@@ -1484,6 +1494,39 @@ async function setHooks(userID: UserID, sessionID: SessionID, hooks: unknown, ac
 	ack?.(updated ? new SocketAck() : new SocketError("Invalid parameter 'hooks'."));
 }
 
+function setAllowSpectators(
+	userID: UserID,
+	sessionID: SessionID,
+	val: boolean,
+	ack: (result: SocketAck & { spectateKey?: string }) => void
+) {
+	if (!SessionsSettingsProps.allowSpectators(val)) return ack?.(new SocketError("Invalid parameter."));
+	const sess = Sessions[sessionID];
+	if (sess.allowSpectators !== val) {
+		sess.allowSpectators = val;
+		if (val) {
+			sess.spectateKey = shortguid();
+		} else {
+			sess.spectateKey = undefined;
+			sweepSpectators(sess);
+		}
+		sess.emitToConnectedNonOwners("sessionOptions", { allowSpectators: sess.allowSpectators });
+	}
+	ack?.(Object.assign(new SocketAck(), { spectateKey: sess.spectateKey }));
+}
+
+// Move every spectator to a new session of their own
+function sweepSpectators(sess: Session) {
+	for (const uid of [...sess.spectators]) {
+		sess.spectators.delete(uid);
+		moveToNewSession(
+			uid,
+			new Message("Spectating disabled", `The owner of session '${sess.id}' disabled spectating.`)
+		);
+	}
+	sess.broadcastSpectators();
+}
+
 const prepareSocketCallback = <T extends Array<unknown>>(
 	callback: (userID: UserID, sessionID: SessionID, ...args: T) => void,
 	ownerOnly = false
@@ -1766,6 +1809,7 @@ io.on("connection", async function (socket) {
 		socket.on("syncBracketMTGO", prepareSocketCallback(syncBracketMTGO, true));
 		socket.on("shareDraftLog", prepareSocketCallback(shareDraftLog, true));
 		socket.on("setHooks", prepareSocketCallback(setHooks, true));
+		socket.on("setAllowSpectators", prepareSocketCallback(setAllowSpectators, true));
 
 		// Apply preferred session settings in case we're creating a new one, filtering out invalid ones.
 		const filteredSettings: Options = {};
@@ -1788,7 +1832,7 @@ io.on("connection", async function (socket) {
 			if (sessionIDInUse(sessionID)) sessionID = newSessionID("CC_");
 		}
 
-		joinSession(sessionID, userID, filteredSettings);
+		joinSession(sessionID, userID, filteredSettings, spectateKeyFromQuery(query));
 
 		if (sessionSettings.cubeCobraID) {
 			if (sessionID !== query.sessionID) Connections[userID].socket.emit("setSession", sessionID);
@@ -1847,7 +1891,12 @@ function newSessionID(prefix: string = ""): SessionID {
 	return sid;
 }
 
-function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSettings: Options = {}) {
+function spectateKeyFromQuery(query: { spectate?: unknown }): string | undefined {
+	if (isString(query.spectate)) return query.spectate;
+	return undefined;
+}
+
+function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSettings: Options = {}, spectateKey?: string) {
 	if (!Connections[userID]) return console.error(`joinSession: No connection found for userID ${userID}`);
 
 	// Fallback to previous session if possible, or generate a new one
@@ -1858,7 +1907,10 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 	};
 
 	if (sessionID in InactiveSessions) {
-		if (InactiveSessions[sessionID].drafting && !(userID in InactiveSessions[sessionID].disconnectedUsers))
+		const canRejoin =
+			userID in InactiveSessions[sessionID].disconnectedUsers ||
+			(spectateKey !== undefined && spectateKey === InactiveSessions[sessionID].spectateKey);
+		if (InactiveSessions[sessionID].drafting && !canRejoin)
 			return refuse(`Session '${sessionID}' is currently drafting.`);
 
 		console.log(`Restoring inactive session '${sessionID}'...`);
@@ -1867,9 +1919,12 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 			delete InactiveSessions[sessionID].deleteTimeout;
 		}
 		// Always having a valid owner is more important than preserving the old one - probably.
+		// Spectators are excluded: a returning spectator should never inherit ownership.
+		const reconnectingPlayer =
+			InactiveSessions[sessionID].ownerIsPlayer && !InactiveSessions[sessionID].spectators?.includes(userID);
 		Sessions[sessionID] = restoreSession(
 			InactiveSessions[sessionID],
-			InactiveSessions[sessionID].ownerIsPlayer ? userID : InactiveSessions[sessionID].owner
+			reconnectingPlayer ? userID : InactiveSessions[sessionID].owner
 		);
 		delete InactiveSessions[sessionID];
 	}
@@ -1883,6 +1938,15 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 			return;
 		}
 
+		// A valid spectate link grants spectator access in any session state. The owner keeps their seat
+		if (spectateKey !== undefined && !sess.spectators.has(userID) && userID !== sess.owner) {
+			if (!sess.allowSpectators || spectateKey !== sess.spectateKey)
+				return refuse(`Invalid spectate link for session (${sessionID}).`);
+			if (sess.drafting && !isDraftState(sess.draftState))
+				return refuse(`Spectating is not supported for this game mode.`);
+			return addSpectatorToSession(userID, sessionID);
+		}
+
 		const bracketLink = sess.bracket
 			? `<br />Bracket is available <a href="/bracket?session=${encodeURIComponent(
 					sessionID
@@ -1892,11 +1956,12 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 		if (sess.drafting) {
 			console.log(
 				`Session ${sessionID}: ${userID} wants to rejoin draft: ${
-					userID in sess.disconnectedUsers ? "Ok!" : "Not allowed."
+					userID in sess.disconnectedUsers || sess.spectators.has(userID) ? "Ok!" : "Not allowed."
 				}`
 			);
 
 			if (userID in sess.disconnectedUsers) sess.reconnectUser(userID);
+			else if (sess.spectators.has(userID)) addSpectatorToSession(userID, sessionID);
 			else
 				return refuse(
 					`This session (${sessionID}) is currently drafting. Please wait for them to finish.${bracketLink}`
@@ -1906,12 +1971,17 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 			return refuse(`This session (${sessionID}) is closed.`);
 		} else if (sess.getHumanPlayerCount() >= sess.maxPlayers) {
 			// Session exists and is full
-			return refuse(
-				`This session (${sessionID}) is full (${sess.users.size}/${sess.maxPlayers} players).${bracketLink}`
-			);
+			if (sess.spectators.has(userID)) addSpectatorToSession(userID, sessionID);
+			else
+				return refuse(
+					`This session (${sessionID}) is full (${sess.users.size}/${sess.maxPlayers} players).${bracketLink}`
+				);
 		} else {
 			addUserToSession(userID, sessionID);
 		}
+	} else if (spectateKey !== undefined) {
+		// Spectate links never create sessions
+		return refuse(`Session (${sessionID}) does not exist anymore.`);
 	} else {
 		addUserToSession(userID, sessionID, defaultSessionSettings);
 	}
@@ -1929,7 +1999,10 @@ function addUserToSession(userID: UserID, sessionID: SessionID, defaultSessionSe
 
 	if (currentSessionID && currentSessionID in Sessions) removeUserFromSession(currentSessionID, userID);
 
-	if (!(sessionID in Sessions)) Sessions[sessionID] = new Session(sessionID, userID, defaultSessionSettings);
+	if (!(sessionID in Sessions)) {
+		Sessions[sessionID] = new Session(sessionID, userID, defaultSessionSettings);
+		if (Sessions[sessionID].allowSpectators) Sessions[sessionID].spectateKey = shortguid();
+	}
 
 	if (userID === Sessions[sessionID].owner && !Sessions[sessionID].ownerIsPlayer) {
 		Connections[userID].sessionID = sessionID;
@@ -1939,9 +2012,27 @@ function addUserToSession(userID: UserID, sessionID: SessionID, defaultSessionSe
 	if (Sessions[sessionID].isPublic) updatePublicSession(sessionID);
 }
 
+// Spectators can only join existing sessions, in contrast to addUserToSession this never creates one.
+function addSpectatorToSession(userID: UserID, sessionID: SessionID) {
+	if (!Connections[userID]) return console.error(`addSpectatorToSession: No connection found for userID ${userID}`);
+
+	const currentSessionID = Connections[userID].sessionID;
+	if (currentSessionID && currentSessionID in Sessions) removeUserFromSession(currentSessionID, userID);
+
+	Sessions[sessionID].addSpectator(userID);
+	Connections[userID].socket.emit("message", new ToastMessage("Joined as spectator"));
+	if (Sessions[sessionID].isPublic) updatePublicSession(sessionID);
+}
+
 function deleteSession(sessionID: SessionID) {
-	const wasPublic = Sessions[sessionID].isPublic;
-	Sessions[sessionID].beforeDelete();
+	const sess = Sessions[sessionID];
+	for (const uid of [...sess.spectators]) {
+		sess.spectators.delete(uid);
+		moveToNewSession(uid, new Message("Session closed", `Session '${sessionID}' was closed.`));
+	}
+
+	const wasPublic = sess.isPublic;
+	sess.beforeDelete();
 	process.nextTick(() => {
 		delete Sessions[sessionID];
 		if (wasPublic) updatePublicSession(sessionID);
@@ -1980,6 +2071,9 @@ function removeUserFromSession(sessionID: SessionID, userID: UserID) {
 				}
 				deleteSession(sessionID);
 			} else sess.notifyUserChange();
+		} else if (sess.spectators.has(userID)) {
+			// Keep drafting spectators around so they can reconnect, like disconnected players
+			if (!sess.drafting) sess.removeSpectator(userID);
 		} else if (userID === sess.owner && !sess.ownerIsPlayer && sess.users.size === 0) {
 			// User was a non-playing owner and alone in this session
 			deleteSession(sessionID);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1683,6 +1683,26 @@ io.on("connection", async function (socket) {
 		});
 	}
 
+	// Spectate links are validated once here and never reach joinSession. The owner keeps their seat
+	const spectateKey = spectateKeyFromQuery(query);
+	const spectatedSession = isString(query.sessionID) ? Sessions[query.sessionID] : undefined;
+	if (spectateKey !== undefined && userID !== spectatedSession?.owner) {
+		const refuseSpectate = (msg: string) => {
+			socket.emit("message", new Message("Cannot spectate session", "", "", msg));
+			socket.disconnect(true);
+		};
+		if (!spectatedSession) return refuseSpectate(`Session (${query.sessionID}) does not exist anymore.`);
+		if (!spectatedSession.allowSpectators || spectateKey !== spectatedSession.spectateKey)
+			return refuseSpectate(`Invalid spectate link for session (${spectatedSession.id}).`);
+		if (spectatedSession.drafting && !isDraftState(spectatedSession.draftState))
+			return refuseSpectate(`Spectating is not supported for this game mode.`);
+
+		socket.on("setUserName", prepareSocketCallback(setUserName));
+		socket.on("chatMessage", prepareSocketCallback(chatMessage));
+		addSpectatorToSession(userID, spectatedSession.id);
+		return;
+	}
+
 	// Personal events
 	socket.on("setUserName", prepareSocketCallback(setUserName));
 	socket.on("setCollection", prepareSocketCallback(setCollection));
@@ -1832,7 +1852,7 @@ io.on("connection", async function (socket) {
 			if (sessionIDInUse(sessionID)) sessionID = newSessionID("CC_");
 		}
 
-		joinSession(sessionID, userID, filteredSettings, spectateKeyFromQuery(query));
+		joinSession(sessionID, userID, filteredSettings);
 
 		if (sessionSettings.cubeCobraID) {
 			if (sessionID !== query.sessionID) Connections[userID].socket.emit("setSession", sessionID);
@@ -1896,7 +1916,7 @@ function spectateKeyFromQuery(query: { spectate?: unknown }): string | undefined
 	return undefined;
 }
 
-function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSettings: Options = {}, spectateKey?: string) {
+function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSettings: Options = {}) {
 	if (!Connections[userID]) return console.error(`joinSession: No connection found for userID ${userID}`);
 
 	// Fallback to previous session if possible, or generate a new one
@@ -1907,10 +1927,7 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 	};
 
 	if (sessionID in InactiveSessions) {
-		const canRejoin =
-			userID in InactiveSessions[sessionID].disconnectedUsers ||
-			(spectateKey !== undefined && spectateKey === InactiveSessions[sessionID].spectateKey);
-		if (InactiveSessions[sessionID].drafting && !canRejoin)
+		if (InactiveSessions[sessionID].drafting && !(userID in InactiveSessions[sessionID].disconnectedUsers))
 			return refuse(`Session '${sessionID}' is currently drafting.`);
 
 		console.log(`Restoring inactive session '${sessionID}'...`);
@@ -1919,12 +1936,9 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 			delete InactiveSessions[sessionID].deleteTimeout;
 		}
 		// Always having a valid owner is more important than preserving the old one - probably.
-		// Spectators are excluded: a returning spectator should never inherit ownership.
-		const reconnectingPlayer =
-			InactiveSessions[sessionID].ownerIsPlayer && !InactiveSessions[sessionID].spectators?.includes(userID);
 		Sessions[sessionID] = restoreSession(
 			InactiveSessions[sessionID],
-			reconnectingPlayer ? userID : InactiveSessions[sessionID].owner
+			InactiveSessions[sessionID].ownerIsPlayer ? userID : InactiveSessions[sessionID].owner
 		);
 		delete InactiveSessions[sessionID];
 	}
@@ -1938,15 +1952,6 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 			return;
 		}
 
-		// A valid spectate link grants spectator access in any session state. The owner keeps their seat
-		if (spectateKey !== undefined && !sess.spectators.has(userID) && userID !== sess.owner) {
-			if (!sess.allowSpectators || spectateKey !== sess.spectateKey)
-				return refuse(`Invalid spectate link for session (${sessionID}).`);
-			if (sess.drafting && !isDraftState(sess.draftState))
-				return refuse(`Spectating is not supported for this game mode.`);
-			return addSpectatorToSession(userID, sessionID);
-		}
-
 		const bracketLink = sess.bracket
 			? `<br />Bracket is available <a href="/bracket?session=${encodeURIComponent(
 					sessionID
@@ -1956,12 +1961,11 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 		if (sess.drafting) {
 			console.log(
 				`Session ${sessionID}: ${userID} wants to rejoin draft: ${
-					userID in sess.disconnectedUsers || sess.spectators.has(userID) ? "Ok!" : "Not allowed."
+					userID in sess.disconnectedUsers ? "Ok!" : "Not allowed."
 				}`
 			);
 
 			if (userID in sess.disconnectedUsers) sess.reconnectUser(userID);
-			else if (sess.spectators.has(userID)) addSpectatorToSession(userID, sessionID);
 			else
 				return refuse(
 					`This session (${sessionID}) is currently drafting. Please wait for them to finish.${bracketLink}`
@@ -1971,17 +1975,12 @@ function joinSession(sessionID: SessionID, userID: UserID, defaultSessionSetting
 			return refuse(`This session (${sessionID}) is closed.`);
 		} else if (sess.getHumanPlayerCount() >= sess.maxPlayers) {
 			// Session exists and is full
-			if (sess.spectators.has(userID)) addSpectatorToSession(userID, sessionID);
-			else
-				return refuse(
-					`This session (${sessionID}) is full (${sess.users.size}/${sess.maxPlayers} players).${bracketLink}`
-				);
+			return refuse(
+				`This session (${sessionID}) is full (${sess.users.size}/${sess.maxPlayers} players).${bracketLink}`
+			);
 		} else {
 			addUserToSession(userID, sessionID);
 		}
-	} else if (spectateKey !== undefined) {
-		// Spectate links never create sessions
-		return refuse(`Session (${sessionID}) does not exist anymore.`);
 	} else {
 		addUserToSession(userID, sessionID, defaultSessionSettings);
 	}
@@ -2072,8 +2071,7 @@ function removeUserFromSession(sessionID: SessionID, userID: UserID) {
 				deleteSession(sessionID);
 			} else sess.notifyUserChange();
 		} else if (sess.spectators.has(userID)) {
-			// Keep drafting spectators around so they can reconnect, like disconnected players
-			if (!sess.drafting) sess.removeSpectator(userID);
+			sess.removeSpectator(userID);
 		} else if (userID === sess.owner && !sess.ownerIsPlayer && sess.users.size === 0) {
 			// User was a non-playing owner and alone in this session
 			deleteSession(sessionID);

--- a/src/server.ts
+++ b/src/server.ts
@@ -1683,10 +1683,13 @@ io.on("connection", async function (socket) {
 		});
 	}
 
-	// Spectate links are validated once here and never reach joinSession. The owner keeps their seat
+	// Spectate links are validated once here and never reach joinSession. Anyone with a seat to return to keeps it
 	const spectateKey = spectateKeyFromQuery(query);
 	const spectatedSession = isString(query.sessionID) ? Sessions[query.sessionID] : undefined;
-	if (spectateKey !== undefined && userID !== spectatedSession?.owner) {
+	const hasSeat =
+		spectatedSession !== undefined &&
+		(userID === spectatedSession.owner || userID in spectatedSession.disconnectedUsers);
+	if (spectateKey !== undefined && !hasSeat) {
 		const refuseSpectate = (msg: string) => {
 			socket.emit("message", new Message("Cannot spectate session", "", "", msg));
 			socket.disconnect(true);

--- a/test/spectators.ts
+++ b/test/spectators.ts
@@ -148,7 +148,7 @@ describe("Spectators", function () {
 			spectate: "000000000000",
 		});
 		badSpectator.once("message", (msg) => {
-			expect(msg.title).to.equal("Cannot join session");
+			expect(msg.title).to.equal("Cannot spectate session");
 			expect(Sessions[sessionID].spectators.has("BadSpectatorID")).to.be.false;
 			badSpectator.disconnect();
 			done();
@@ -163,7 +163,7 @@ describe("Spectators", function () {
 			spectate: spectateKey,
 		});
 		lostSpectator.once("message", (msg) => {
-			expect(msg.title).to.equal("Cannot join session");
+			expect(msg.title).to.equal("Cannot spectate session");
 			expect(Sessions["NoSuchSession"]).to.not.exist;
 			lostSpectator.disconnect();
 			done();
@@ -289,13 +289,22 @@ describe("Spectators", function () {
 			clients[nonOwnerIdx].emit("chatMessage", { author: "id1", text: "Player talk", timestamp: 0 });
 		});
 
-		it("A spectator disconnect does not pause the draft and allows reconnection.", function (done) {
+		it("A spectator disconnect removes them immediately and does not pause the draft.", function (done) {
 			secondSpectator.disconnect();
 			setTimeout(() => {
 				expect(Sessions[sessionID].draftPaused).to.be.false;
-				expect(Sessions[sessionID].spectators.has(secondSpectatorUserID)).to.be.true;
+				expect(Sessions[sessionID].spectators.has(secondSpectatorUserID)).to.be.false;
 				done();
 			}, 100);
+		});
+
+		it("A disconnected spectator can rejoin mid-draft through the same link.", function (done) {
+			secondSpectator.once("draftLogLive", (data) => {
+				expect(data.log).to.exist;
+				expect(Sessions[sessionID].spectators.has(secondSpectatorUserID)).to.be.true;
+				done();
+			});
+			secondSpectator.connect();
 		});
 
 		it("Pick until the draft ends, spectators receive endDraft.", function (done) {
@@ -325,9 +334,8 @@ describe("Spectators", function () {
 			for (const c of clients) c.emit("pickCard", { pickedCards: [0], burnedCards: [] }, () => {});
 		});
 
-		it("Spectators that never reconnected are dropped when the draft ends.", function (done) {
-			expect(Sessions[sessionID].spectators.has(secondSpectatorUserID)).to.be.false;
-			expect(Sessions[sessionID].spectators.has(spectatorUserID)).to.be.true;
+		after(function (done) {
+			secondSpectator?.disconnect();
 			done();
 		});
 	});
@@ -367,6 +375,12 @@ describe("Spectators", function () {
 				});
 				clients[ownerIdx].emit("setAllowSpectators", false, ackNoError);
 			});
+		});
+
+		it("Session.addSpectator is a no-op while spectating is disabled.", function (done) {
+			Sessions[sessionID].addSpectator(spectatorUserID);
+			expect(Sessions[sessionID].spectators.size).to.equal(0);
+			done();
 		});
 	});
 });
@@ -421,7 +435,7 @@ describe("Spectators in unsupported game modes", function () {
 			spectate: spectateKey,
 		});
 		spectator.once("message", (msg) => {
-			expect(msg.title).to.equal("Cannot join session");
+			expect(msg.title).to.equal("Cannot spectate session");
 			expect(Sessions[sessionID].spectators.has("WinstonSpectatorID")).to.be.false;
 			spectator.disconnect();
 			done();
@@ -499,7 +513,25 @@ describe("Spectators across a server restart", function () {
 			});
 	});
 
-	it("The spectator reconnects through the same link without inheriting ownership.", function (done) {
+	it("The spectator cannot rejoin while the session is inactive.", function (done) {
+		spectator.once("message", (msg) => {
+			expect(msg.title).to.equal("Cannot spectate session");
+			done();
+		});
+		spectator.connect();
+	});
+
+	it("Players reconnect, the owner first so they keep ownership.", function (done) {
+		const nonOwner = clients[(ownerIdx + 1) % clients.length];
+		clients[ownerIdx].once("rejoinDraft", () => {
+			expect(Sessions[sessionID].owner).to.equal(ownerUserID);
+			nonOwner.once("rejoinDraft", () => done());
+			nonOwner.connect();
+		});
+		clients[ownerIdx].connect();
+	});
+
+	it("The spectator rejoins through the same link once the session is live again.", function (done) {
 		spectator.once("draftLogLive", (data) => {
 			expect(data.log).to.exist;
 			expect(Sessions[sessionID].spectators.has(spectatorUserID)).to.be.true;
@@ -511,17 +543,8 @@ describe("Spectators across a server restart", function () {
 		spectator.connect();
 	});
 
-	it("Players reconnect and the draft can be stopped.", function (done) {
-		let reconnected = 0;
-		for (const c of clients) {
-			c.once("rejoinDraft", () => {
-				++reconnected;
-				if (reconnected === clients.length) {
-					clients[ownerIdx].emit("stopDraft");
-					done();
-				}
-			});
-			c.connect();
-		}
+	it("The draft can be stopped.", function (done) {
+		clients[ownerIdx].emit("stopDraft");
+		done();
 	});
 });

--- a/test/spectators.ts
+++ b/test/spectators.ts
@@ -289,6 +289,31 @@ describe("Spectators", function () {
 			clients[nonOwnerIdx].emit("chatMessage", { author: "id1", text: "Player talk", timestamp: 0 });
 		});
 
+		it("Spectator game messages are not handled at all.", function (done) {
+			let acked = false;
+			spectator.emit("pickCard", { pickedCards: [0], burnedCards: [] }, () => {
+				acked = true;
+			});
+			setTimeout(() => {
+				expect(acked, "pickCard must not be handled for spectators").to.be.false;
+				done();
+			}, 100);
+		});
+
+		it("A disconnected player reconnecting through the spectate link keeps their seat.", function (done) {
+			const playerClient = clients[nonOwnerIdx];
+			const playerUserID = getUID(playerClient);
+			(playerClient.io.opts.query as Record<string, unknown>).spectate = spectateKey;
+			playerClient.once("rejoinDraft", () => {
+				expect(Sessions[sessionID].spectators.has(playerUserID)).to.be.false;
+				expect(Sessions[sessionID].users.has(playerUserID)).to.be.true;
+				delete (playerClient.io.opts.query as Record<string, unknown>).spectate;
+				done();
+			});
+			playerClient.disconnect();
+			setTimeout(() => playerClient.connect(), 50);
+		});
+
 		it("A spectator disconnect removes them immediately and does not pause the draft.", function (done) {
 			secondSpectator.disconnect();
 			setTimeout(() => {

--- a/test/spectators.ts
+++ b/test/spectators.ts
@@ -1,0 +1,527 @@
+"use strict";
+import { before, after, beforeEach, afterEach, describe, it } from "mocha";
+import { expect } from "chai";
+import { Sessions } from "../src/Session.js";
+import { Connections } from "../src/Connection.js";
+import { simulateRestart } from "../src/Persistence.js";
+import {
+	makeClients,
+	connectClient,
+	enableLogs,
+	disableLogs,
+	waitForClientDisconnects,
+	waitForSocket,
+	ackNoError,
+	getUID,
+} from "./src/common.js";
+
+describe("Spectators", function () {
+	let clients: ReturnType<typeof makeClients> = [];
+	const sessionID = "SpectatorsTestSession";
+	let ownerIdx = 0;
+	let nonOwnerIdx = 1;
+	let spectateKey = "";
+	const spectatorUserID = "SpectatorID1";
+	let spectator: ReturnType<typeof connectClient>;
+
+	beforeEach(function (done) {
+		disableLogs();
+		done();
+	});
+
+	afterEach(function (done) {
+		enableLogs(this.currentTest?.state === "failed");
+		done();
+	});
+
+	before(function (done) {
+		clients = makeClients(
+			[
+				{ userID: "id0", sessionID: sessionID, userName: "Client0" },
+				{ userID: "id1", sessionID: sessionID, userName: "Client1" },
+			],
+			done
+		);
+	});
+
+	after(function (done) {
+		disableLogs();
+		for (const c of clients) c.disconnect();
+		spectator?.disconnect();
+		waitForClientDisconnects(done);
+	});
+
+	it("2 clients with different userIDs should be connected.", function (done) {
+		expect(Object.keys(Connections).length).to.equal(2);
+		ownerIdx = clients.findIndex((c) => getUID(c) === Sessions[sessionID].owner);
+		nonOwnerIdx = (ownerIdx + 1) % clients.length;
+		done();
+	});
+
+	it("Owner disables spectating, the ack carries no key.", function (done) {
+		clients[ownerIdx].emit("setAllowSpectators", false, (r) => {
+			ackNoError(r);
+			expect(r.spectateKey).to.be.undefined;
+			expect(Sessions[sessionID].allowSpectators).to.be.false;
+			expect(Sessions[sessionID].spectateKey).to.be.undefined;
+			done();
+		});
+	});
+
+	it("Non-owner cannot enable spectating.", function (done) {
+		clients[nonOwnerIdx].emit("setAllowSpectators", true, (r) => {
+			expect(r.code).to.not.equal(0);
+			expect(Sessions[sessionID].allowSpectators).to.be.false;
+			done();
+		});
+	});
+
+	it("Enabling spectating returns the key to the owner and never to other players.", function (done) {
+		clients[nonOwnerIdx].once("sessionOptions", (options) => {
+			expect(options.allowSpectators).to.be.true;
+			expect(options.spectateKey, "spectateKey must never reach non-owners").to.be.undefined;
+			done();
+		});
+		clients[ownerIdx].emit("setAllowSpectators", true, (r) => {
+			ackNoError(r);
+			expect(r.spectateKey).to.match(/^[0-9a-f]{12}$/);
+			expect(r.spectateKey).to.equal(Sessions[sessionID].spectateKey);
+			spectateKey = r.spectateKey!;
+		});
+	});
+
+	it("Re-enabling returns the same key, disabling and enabling again rotates it.", function (done) {
+		clients[ownerIdx].emit("setAllowSpectators", true, (r) => {
+			expect(r.spectateKey).to.equal(spectateKey);
+			clients[ownerIdx].emit("setAllowSpectators", false, (r) => {
+				expect(r.spectateKey).to.be.undefined;
+				clients[ownerIdx].emit("setAllowSpectators", true, (r) => {
+					ackNoError(r);
+					expect(r.spectateKey).to.not.equal(spectateKey);
+					spectateKey = r.spectateKey!;
+					done();
+				});
+			});
+		});
+	});
+
+	it("A user opening the spectator link joins as a spectator, everyone is notified.", function (done) {
+		let joined = false;
+		let notified = false;
+		const checkDone = () => {
+			if (joined && notified) {
+				expect(Sessions[sessionID].spectators.has(spectatorUserID)).to.be.true;
+				expect(Sessions[sessionID].users.has(spectatorUserID)).to.be.false;
+				done();
+			}
+		};
+		clients[nonOwnerIdx].once("sessionSpectators", (spectators) => {
+			expect(spectators).to.deep.include({ userID: spectatorUserID, userName: "Spectator1" });
+			notified = true;
+			checkDone();
+		});
+		spectator = connectClient({
+			userID: spectatorUserID,
+			sessionID: sessionID,
+			userName: "Spectator1",
+			spectate: spectateKey,
+		});
+		spectator.on("message", (msg) => {
+			if (msg.title === "Joined as spectator") {
+				spectator.off("message");
+				joined = true;
+				checkDone();
+			}
+		});
+	});
+
+	it("Spectators do not appear in the player list.", function (done) {
+		expect(Sessions[sessionID].getHumanPlayerCount()).to.equal(2);
+		done();
+	});
+
+	it("A user with an invalid key is refused.", function (done) {
+		const badSpectator = connectClient({
+			userID: "BadSpectatorID",
+			sessionID: sessionID,
+			userName: "BadSpectator",
+			spectate: "000000000000",
+		});
+		badSpectator.once("message", (msg) => {
+			expect(msg.title).to.equal("Cannot join session");
+			expect(Sessions[sessionID].spectators.has("BadSpectatorID")).to.be.false;
+			badSpectator.disconnect();
+			done();
+		});
+	});
+
+	it("A spectator link to a non-existing session is refused without creating it.", function (done) {
+		const lostSpectator = connectClient({
+			userID: "LostSpectatorID",
+			sessionID: "NoSuchSession",
+			userName: "LostSpectator",
+			spectate: spectateKey,
+		});
+		lostSpectator.once("message", (msg) => {
+			expect(msg.title).to.equal("Cannot join session");
+			expect(Sessions["NoSuchSession"]).to.not.exist;
+			lostSpectator.disconnect();
+			done();
+		});
+	});
+
+	it("Spectators do not count toward the player limit.", function (done) {
+		clients[ownerIdx].emit("setMaxPlayers", 2);
+		const thirdPlayer = connectClient({
+			userID: "ThirdPlayerID",
+			sessionID: sessionID,
+			userName: "Client2",
+		});
+		thirdPlayer.once("message", (msg) => {
+			expect(msg.title, "a third player should be refused, the spectator does not hold a seat").to.equal(
+				"Cannot join session"
+			);
+			thirdPlayer.disconnect();
+			clients[ownerIdx].emit("setMaxPlayers", 8);
+			done();
+		});
+	});
+
+	it("Spectator chat reaches players while no game is in progress.", function (done) {
+		clients[nonOwnerIdx].once("chatMessage", (msg) => {
+			expect(msg.text).to.equal("Hello from the lobby");
+			done();
+		});
+		spectator.emit("chatMessage", { author: spectatorUserID, text: "Hello from the lobby", timestamp: 0 });
+	});
+
+	describe("During a draft", function () {
+		const secondSpectatorUserID = "SpectatorID2";
+		let secondSpectator: ReturnType<typeof connectClient>;
+		const clientStates: { [uid: string]: { pickNumber: number; booster: unknown[] } } = {};
+		let spectatedPicks = 0;
+		let pickAlerts = 0;
+		let playerSawSpectatorChat = false;
+
+		it("Setup: bots and private draft logs.", function (done) {
+			clients[ownerIdx].emit("setBots", 6);
+			clients[ownerIdx].emit("setDraftLogRecipients", "none");
+			done();
+		});
+
+		it("Draft start sends the spectator startDraft, a skipPick draftState and the live log.", function (done) {
+			let startReceived = false;
+			let stateReceived = false;
+			let logReceived = false;
+			const checkDone = () => {
+				if (startReceived && stateReceived && logReceived) done();
+			};
+			spectator.once("startDraft", () => {
+				startReceived = true;
+				checkDone();
+			});
+			spectator.once("draftState", (s) => {
+				expect((s as { skipPick: boolean }).skipPick).to.be.true;
+				stateReceived = true;
+				checkDone();
+			});
+			spectator.once("draftLogLive", (data) => {
+				expect(data.log).to.exist;
+				logReceived = true;
+				checkDone();
+			});
+			for (const c of clients)
+				c.once("draftState", (s) => {
+					const state = s as { pickNumber: number; booster: unknown[] };
+					clientStates[getUID(c)] = { pickNumber: -1, booster: state.booster };
+				});
+			clients[ownerIdx].emit("startDraft", ackNoError);
+		});
+
+		it("Picks are streamed to the spectator even with draftLogRecipients set to none.", function (done) {
+			spectator.on("draftLogLive", (data) => {
+				if (data.pick) ++spectatedPicks;
+			});
+			spectator.on("pickAlert", () => {
+				++pickAlerts;
+				if (pickAlerts === clients.length) {
+					expect(spectatedPicks).to.be.greaterThanOrEqual(clients.length);
+					done();
+				}
+			});
+			for (const c of clients) c.emit("pickCard", { pickedCards: [0], burnedCards: [] }, ackNoError);
+		});
+
+		it("A spectator joining mid-draft receives the catch-up snapshot.", function (done) {
+			secondSpectator = connectClient({
+				userID: secondSpectatorUserID,
+				sessionID: sessionID,
+				userName: "Spectator2",
+				spectate: spectateKey,
+			});
+			secondSpectator.once("draftLogLive", (data) => {
+				expect(data.log).to.exist;
+				expect(Sessions[sessionID].spectators.has(secondSpectatorUserID)).to.be.true;
+				done();
+			});
+		});
+
+		it("Spectator chat does not reach players during the draft, but reaches other spectators.", function (done) {
+			clients[nonOwnerIdx].once("chatMessage", () => {
+				playerSawSpectatorChat = true;
+			});
+			secondSpectator.once("chatMessage", (msg) => {
+				expect(msg.text).to.equal("Secret spectator talk");
+				setTimeout(() => {
+					expect(playerSawSpectatorChat, "players should not receive spectator chat mid-draft").to.be.false;
+					clients[nonOwnerIdx].off("chatMessage");
+					done();
+				}, 100);
+			});
+			spectator.emit("chatMessage", { author: spectatorUserID, text: "Secret spectator talk", timestamp: 0 });
+		});
+
+		it("Player chat reaches spectators during the draft.", function (done) {
+			spectator.once("chatMessage", (msg) => {
+				expect(msg.text).to.equal("Player talk");
+				done();
+			});
+			clients[nonOwnerIdx].emit("chatMessage", { author: "id1", text: "Player talk", timestamp: 0 });
+		});
+
+		it("A spectator disconnect does not pause the draft and allows reconnection.", function (done) {
+			secondSpectator.disconnect();
+			setTimeout(() => {
+				expect(Sessions[sessionID].draftPaused).to.be.false;
+				expect(Sessions[sessionID].spectators.has(secondSpectatorUserID)).to.be.true;
+				done();
+			}, 100);
+		});
+
+		it("Pick until the draft ends, spectators receive endDraft.", function (done) {
+			let spectatorSawEnd = false;
+			let draftEnded = 0;
+			const checkDone = () => {
+				if (spectatorSawEnd && draftEnded === clients.length) done();
+			};
+			spectator.once("endDraft", () => {
+				spectatorSawEnd = true;
+				checkDone();
+			});
+			for (const c of clients) {
+				c.on("draftState", (s) => {
+					const state = s as { pickNumber: number; booster: unknown[]; boosterCount: number };
+					if (state.boosterCount > 0 && state.pickNumber !== clientStates[getUID(c)].pickNumber) {
+						clientStates[getUID(c)].pickNumber = state.pickNumber;
+						c.emit("pickCard", { pickedCards: [0], burnedCards: [] }, () => {});
+					}
+				});
+				c.once("endDraft", () => {
+					c.off("draftState");
+					++draftEnded;
+					checkDone();
+				});
+			}
+			for (const c of clients) c.emit("pickCard", { pickedCards: [0], burnedCards: [] }, () => {});
+		});
+
+		it("Spectators that never reconnected are dropped when the draft ends.", function (done) {
+			expect(Sessions[sessionID].spectators.has(secondSpectatorUserID)).to.be.false;
+			expect(Sessions[sessionID].spectators.has(spectatorUserID)).to.be.true;
+			done();
+		});
+	});
+
+	describe("Moderation", function () {
+		it("Non-owners cannot remove a spectator.", function (done) {
+			clients[nonOwnerIdx].emit("removePlayer", spectatorUserID);
+			setTimeout(() => {
+				expect(Sessions[sessionID].spectators.has(spectatorUserID)).to.be.true;
+				done();
+			}, 100);
+		});
+
+		it("The owner can remove a spectator, who is moved to a new session.", function (done) {
+			spectator.once("setSession", (newSessionID) => {
+				expect(newSessionID).to.not.equal(sessionID);
+				expect(Sessions[sessionID].spectators.has(spectatorUserID)).to.be.false;
+				done();
+			});
+			clients[ownerIdx].emit("removePlayer", spectatorUserID);
+		});
+
+		it("Disabling spectating sweeps every remaining spectator out.", function (done) {
+			const sweptSpectator = connectClient({
+				userID: "SweptSpectatorID",
+				sessionID: sessionID,
+				userName: "Spectator3",
+				spectate: spectateKey,
+			});
+			sweptSpectator.once("sessionOptions", () => {
+				sweptSpectator.once("setSession", (newSessionID) => {
+					expect(newSessionID).to.not.equal(sessionID);
+					expect(Sessions[sessionID].spectators.size).to.equal(0);
+					expect(Sessions[sessionID].spectateKey).to.be.undefined;
+					sweptSpectator.disconnect();
+					done();
+				});
+				clients[ownerIdx].emit("setAllowSpectators", false, ackNoError);
+			});
+		});
+	});
+});
+
+describe("Spectators in unsupported game modes", function () {
+	let clients: ReturnType<typeof makeClients> = [];
+	const sessionID = "SpectatorsWinstonSession";
+	let ownerIdx = 0;
+	let spectateKey = "";
+
+	beforeEach(function (done) {
+		disableLogs();
+		done();
+	});
+
+	afterEach(function (done) {
+		enableLogs(this.currentTest?.state === "failed");
+		done();
+	});
+
+	before(function (done) {
+		clients = makeClients(
+			[
+				{ userID: "wid0", sessionID: sessionID, userName: "Client0" },
+				{ userID: "wid1", sessionID: sessionID, userName: "Client1" },
+			],
+			done
+		);
+	});
+
+	after(function (done) {
+		disableLogs();
+		for (const c of clients) c.disconnect();
+		waitForClientDisconnects(done);
+	});
+
+	it("Setup: enable spectating and start a Winston draft.", function (done) {
+		ownerIdx = clients.findIndex((c) => getUID(c) === Sessions[sessionID].owner);
+		clients[ownerIdx].emit("setAllowSpectators", true, (r) => {
+			ackNoError(r);
+			spectateKey = r.spectateKey!;
+			clients[(ownerIdx + 1) % clients.length].once("startWinstonDraft", () => done());
+			clients[ownerIdx].emit("startWinstonDraft", 6, 3, true, ackNoError);
+		});
+	});
+
+	it("A spectator link is refused while an unsupported game mode is running.", function (done) {
+		const spectator = connectClient({
+			userID: "WinstonSpectatorID",
+			sessionID: sessionID,
+			userName: "Spectator1",
+			spectate: spectateKey,
+		});
+		spectator.once("message", (msg) => {
+			expect(msg.title).to.equal("Cannot join session");
+			expect(Sessions[sessionID].spectators.has("WinstonSpectatorID")).to.be.false;
+			spectator.disconnect();
+			done();
+		});
+	});
+});
+
+describe("Spectators across a server restart", function () {
+	let clients: ReturnType<typeof makeClients> = [];
+	const sessionID = "SpectatorsRestartSession";
+	let ownerIdx = 0;
+	let ownerUserID = "";
+	let spectateKey = "";
+	const spectatorUserID = "RestartSpectatorID";
+	let spectator: ReturnType<typeof connectClient>;
+
+	beforeEach(function (done) {
+		disableLogs();
+		done();
+	});
+
+	afterEach(function (done) {
+		enableLogs(this.currentTest?.state === "failed");
+		done();
+	});
+
+	before(function (done) {
+		clients = makeClients(
+			[
+				{ userID: "rid0", sessionID: sessionID, userName: "Client0" },
+				{ userID: "rid1", sessionID: sessionID, userName: "Client1" },
+			],
+			done
+		);
+	});
+
+	after(function (done) {
+		disableLogs();
+		for (const c of clients) c.disconnect();
+		spectator?.disconnect();
+		waitForClientDisconnects(done);
+	});
+
+	it("Setup: spectator joins, draft starts.", function (done) {
+		ownerIdx = clients.findIndex((c) => getUID(c) === Sessions[sessionID].owner);
+		ownerUserID = getUID(clients[ownerIdx]);
+		clients[ownerIdx].emit("setBots", 6);
+		clients[ownerIdx].emit("setAllowSpectators", true, (r) => {
+			ackNoError(r);
+			spectateKey = r.spectateKey!;
+			spectator = connectClient({
+				userID: spectatorUserID,
+				sessionID: sessionID,
+				userName: "Spectator1",
+				spectate: spectateKey,
+			});
+			spectator.once("sessionSpectators", () => {
+				clients[ownerIdx].emit("startDraft", ackNoError);
+			});
+			spectator.once("startDraft", () => done());
+		});
+	});
+
+	it("Simulate server restart.", async function () {
+		await simulateRestart();
+	});
+
+	it("All clients are disconnected.", function (done) {
+		let closed = 0;
+		const sockets = [...clients, spectator];
+		for (const s of sockets)
+			waitForSocket(s, () => {
+				++closed;
+				if (closed === sockets.length) done();
+			});
+	});
+
+	it("The spectator reconnects through the same link without inheriting ownership.", function (done) {
+		spectator.once("draftLogLive", (data) => {
+			expect(data.log).to.exist;
+			expect(Sessions[sessionID].spectators.has(spectatorUserID)).to.be.true;
+			expect(Sessions[sessionID].owner, "a returning spectator must not become owner").to.equal(ownerUserID);
+			expect(Sessions[sessionID].allowSpectators).to.be.true;
+			expect(Sessions[sessionID].spectateKey).to.equal(spectateKey);
+			done();
+		});
+		spectator.connect();
+	});
+
+	it("Players reconnect and the draft can be stopped.", function (done) {
+		let reconnected = 0;
+		for (const c of clients) {
+			c.once("rejoinDraft", () => {
+				++reconnected;
+				if (reconnected === clients.length) {
+					clients[ownerIdx].emit("stopDraft");
+					done();
+				}
+			});
+			c.connect();
+		}
+	});
+});


### PR DESCRIPTION
- Sessions can opt in with the new `allowSpectators` setting. Enabling it generates a key and a shareable link that joins anyone directly as a spectator, even while a draft is in progress.
- Spectators follow the draft through the live feed previously reserved for the non-playing owner, chat without reaching drafters mid-game, and show as a number with a dropdown in the player bar
- Owners can remove individual spectators, and disabling the setting rotates the key and clears the audience; ~~spectators and their access survive server restarts~~ -> spectators are removed the moment they disconnect and their link re-validates on every connection, after a server restart they rejoin once a player restores the session
- Spectate links are validated once at connection time and spectators never enter the regular join path, they only get the chat and username handlers
- The spectator dropdown gained Copy Link and Disable buttons so the owner can manage spectating mid-draft, disabling asks for confirmation and removes every spectator. The settings panel shows only the copy icon, never the key itself

**setting:**
<img width="1909" height="428" alt="Screenshot from 2026-06-05 00-50-00" src="https://github.com/user-attachments/assets/9c896d24-e894-492d-a981-8a8000552039" />

**joined as spectator**
<img width="1909" height="428" alt="Screenshot from 2026-06-05 00-50-14" src="https://github.com/user-attachments/assets/eadc92e6-1b1d-483a-9235-bfbb10b26781" />

**owner kick**
<img width="742" height="204" alt="image" src="https://github.com/user-attachments/assets/1b664da8-0d63-4691-aa42-f59775d33a76" />

**chat hidden to players during draft**
| Spectator POV | Players |
|---|---|
| <img width="1916" height="390" alt="Screenshot from 2026-06-05 01-09-26" src="https://github.com/user-attachments/assets/4de26809-545f-4ed1-9cf3-f813c59ad229" /> | <img width="1916" height="390" alt="image" src="https://github.com/user-attachments/assets/f2fa35f3-9064-426c-832d-c28d54088553" />  |
