### PR TITLE
Fix Featured Communities layout overflow on mobile

### DIFF
--- a/client/src/components/Communities.vue
+++ b/client/src/components/Communities.vue
@@ -25,7 +25,7 @@
 								</span>
 								<span v-if="c.discord_member_count"> ({{ c.discord_member_count }} members)</span>
 							</a>
-							<a v-if="c.links.youtube" :href="c.links.twitter" target="_blank">
+							<a v-if="c.links.twitter" :href="c.links.twitter" target="_blank">
 								<font-awesome-icon :icon="['brands', 'twitter']" /><span class="link-label">
 									Twitter
 								</span>
@@ -457,6 +457,18 @@ h2 {
 
 	.name {
 		text-align: center;
+	}
+
+	.carousel-controls {
+		width: auto;
+		max-width: 100%;
+	}
+
+	.bubbles {
+		flex: 1;
+		flex-wrap: wrap;
+		justify-content: center;
+		min-width: 0;
 	}
 }
 

--- a/client/src/css/chat.css
+++ b/client/src/css/chat.css
@@ -84,3 +84,9 @@
 	margin-left: -7px;
 	margin-top: -14px;
 }
+
+@media (max-width: 900px) {
+	.chat-bubble {
+		min-width: 0;
+	}
+}


### PR DESCRIPTION
## Summary

Fixes horizontal overflow (and the resulting page scroll) on the welcome page at mobile widths, plus a small Twitter-link bug in the Featured Communities carousel.

## Changes

- **Carousel nav dots** — capped `.carousel-controls` to the container width and let `.bubbles` wrap, so the row of dots no longer runs off-screen. With the current number of communities this was forcing a horizontal page scroll and shifting the visible card off-center.
- **Chat bubbles** — on mobile a player card stretches to full width, so the chat bubble's `min-width: 100%` (plus its `left: 1em` offset) pushed it past the viewport even while empty/invisible. Now sized to its content below 900px; the visible popup and layout on desktop are unchanged.
- **Twitter link** — its visibility keyed off `c.links.youtube` while it pointed at `c.links.twitter`, so a community with a YouTube link but no Twitter rendered a broken link. It now renders only when `c.links.twitter` is set.

## Testing

Verified at 360px and 393px widths: no horizontal page scroll in idle, short-message, and long-message chat states; carousel card stays aligned and the nav dots wrap into centered rows. Player reorder chevrons and the visible chat popup are unaffected.

## Before / After

|  | Before | After |
| :--- | :---: | :---: |
| **Carousel** (360px) | <img width="300" alt="before-carousel" src="https://github.com/user-attachments/assets/1c3103f0-88ab-4d53-8ec4-5f9f3a2cbb62" /> | <img width="300" alt="after-carousel" src="https://github.com/user-attachments/assets/261b71dd-8f43-48ed-a0ce-06057c48f74f" /> |
| **Chat bubble** (360px) | <img width="300" alt="before-bubble" src="https://github.com/user-attachments/assets/ee62ebe5-7f65-448a-b865-821e11b1a9a1" /> | <img width="300" alt="after-bubble" src="https://github.com/user-attachments/assets/60d8215d-affc-4618-9045-cb49c379b84d" /> |
