### PR TITLE
[Client] Add a Moxgate export button

### DIFF
--- a/client/src/components/ExportDropdown.vue
+++ b/client/src/components/ExportDropdown.vue
@@ -36,6 +36,13 @@
 					<font-awesome-icon icon="fa-solid fa-file-download" class="button-icon" />
 				</button>
 			</div>
+			<div class="header">Play online</div>
+			<button
+				@click="exportToMoxgate()"
+				v-tooltip.right="'Open this deck on Moxgate, in your browser. Nothing to install.'"
+			>
+				<font-awesome-icon icon="fa-solid fa-external-link-alt" class="button-icon" />Moxgate
+			</button>
 			<template v-if="hasCustomCards">
 				<div class="header">External services</div>
 				<button
@@ -165,6 +172,18 @@ function exportDeckToFaBrary() {
 	for (const cardID of cardIDs) url += `&cards=${cardID}`;
 
 	window.open(url);
+}
+
+// Moxgate plays real Magic in the browser, so unlike the Cubecana targets below
+// this one sends the full export: the (SET) collector-number tags let it show the
+// printings that were actually drafted. Arena remaps a handful of set codes
+// (DOM -> DAR, the Alchemy Y-sets), which Scryfall does not know; Moxgate falls
+// back to looking those up by name, so the card is still right and only the art
+// defaults. Leaving the ticket off makes this a deck-only link: it imports and
+// saves the deck, and stops there rather than opening a table.
+function exportToMoxgate() {
+	const decklist = exportDeckMTGA(true);
+	window.open(`https://moxgate.com/play?v=1&src=draftmancer&dt=${encodeURIComponent(decklist)}`);
 }
 
 function exportToCubecana(site: "inktable" | "lorcanito" | "tts" | "duelsink") {


### PR DESCRIPTION
Hi Senryoku — following up on our Discord conversation about exporting a drafted deck to Moxgate. This is the smallest version of that: one button, no dependencies, no server changes on your side.

[Moxgate](https://moxgate.com) is a browser MTG simulator, so a deck can go from Draftmancer into an actual game without an install or an account.

## What it does

Adds a **Moxgate** entry to `ExportDropdown.vue`, in the always-visible section rather than the `hasCustomCards` block, since it's for Magic decks:

<img src="https://raw.githubusercontent.com/hainix/Draftmancer/pr-screenshots/.pr-shots/01-export-dropdown.png" width="220">

The whole implementation is the same shape as the existing FaBrary and Cubecana exports — build a URL, `window.open` it:

```ts
function exportToMoxgate() {
	const decklist = exportDeckMTGA(true);
	window.open(`https://moxgate.com/play?v=1&src=draftmancer&dt=${encodeURIComponent(decklist)}`);
}
```

That's the entire diff besides the template entry. No new dependency — I built Moxgate's side around what you already have rather than asking you to add a compression library for one button.

Clicking it imports the deck and stops there: saved to the player's deck library, ready to play solo or take to a table. It does not create a room or bounce anyone into a game.

<img src="https://raw.githubusercontent.com/hainix/Draftmancer/pr-screenshots/.pr-shots/02-moxgate-arrival.jpeg" width="720">

That screenshot is a real round trip from this branch: a 6-booster Hobbit sealed pool, all 84 cards, exported and landed — accented names (Óin, Fíli, Glóin) and apostrophes included.

## Why `full = true`

Cubecana gets `exportDeckMTGA(false)`; this sends the full export instead. The `(SET)` collector-number tags let Moxgate show the printings that were actually opened, which matters more for a simulator that renders the cards than for a list importer.

The known rough edge: Arena remaps a few set codes Scryfall doesn't recognise (`DOM` → `DAR`, the Alchemy `Y` sets). Moxgate falls back to a name lookup for those, so the card is still correct and only the art defaults to another printing. Happy to switch to `false` if you'd rather avoid that entirely.

## Moxgate's side

`dt=` — the decklist as ordinary URL-encoded text — is new, added specifically so this integration needs nothing but `encodeURIComponent`. It sits beside the existing compressed `d=` parameter, which is still there if URL length ever becomes a concern for cube-sized pools. Both are documented at [moxgate.com/developer/challenge-link](https://www.moxgate.com/developer/challenge-link/).

**This is live as of 2026-08-10**, so the button works the moment you check the branch out — nothing to wait on. You can click the exact URL the button builds here: [deck-only export](https://www.moxgate.com/play?v=1&src=draftmancer&dt=Deck%0A2%20Fervent%20Champion%0A2%20Rimrock%20Knight%0A2%20Bonecrusher%20Giant%0A2%20Robber%20of%20the%20Rich%0A2%20Anax%2C%20Hardened%20in%20the%20Forge%0A1%20Torbran%2C%20Thane%20of%20Red%20Fell%0A2%20Shock%0A2%20Lightning%20Strike%0A2%20Skewer%20the%20Critics%0A2%20Play%20with%20Fire%0A2%20Reckless%20Impulse%0A1%20Light%20Up%20the%20Stage%0A1%20Embercleave%0A17%20Mountain%0A%0ASideboard%0A2%20Abrade%0A1%20Chandra%2C%20Torch%20of%20Defiance).

## About the tournament bracket

You asked whether something could get a whole pod into a room together. Having read `Brackets.ts`, I think the answer is that you don't need it — Single, Double, Swiss and Team all pair players 1v1, so a table per pairing is the right unit.

Moxgate already does that with the same URL plus a ticket: both players in a match click a link carrying the same `t=` value and their own deck, and they land at the same table.

```ts
`https://moxgate.com/play?t=match-${matchID}&v=1&dt=${encodeURIComponent(decklist)}`
```

I left it out of this PR deliberately — it needs the viewer's deck threaded down into `BracketMatch.vue`, which is a real change to your component tree rather than a one-line addition, and I'd rather you tell me where you want it than guess. Glad to write it as a follow-up if it's interesting.

## Checks

- `npm run client-type-check` passes (your pre-commit hook ran it)
- prettier clean via `lint-staged`
- verified in a local build: sealed pool → export → deck imported, all 84 cards resolved including accented names (Óin, Fíli, Glóin) and apostrophes

<img src="https://raw.githubusercontent.com/hainix/Draftmancer/pr-screenshots/.pr-shots/03-dropdown-in-context.jpeg" width="720">

No hard feelings at all if this isn't a direction you want to go — thanks for building Draftmancer either way, a lot of us got our start drafting on it.
